### PR TITLE
incorrect module name in NODE_MODULE definition

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -17,4 +17,4 @@ init(Handle<Object> target) {
 	Contour::Init(target);
 };
 
-NODE_MODULE(binding, init)
+NODE_MODULE(opencv, init)


### PR DESCRIPTION
NODE_MODULE(binding, init) should be changed to NODE_MODULE(opencv, init) in src/init.cc
