### PR TITLE
fixed require('buffers')

### DIFF
--- a/lib/opencv.js
+++ b/lib/opencv.js
@@ -1,5 +1,5 @@
 var Stream = require('stream').Stream
-  , Buffers = require('buffer')
+  , Buffers = require('buffers')
   , util = require('util');
 
 var bindings = require('./bindings')


### PR DESCRIPTION
fixed `require('buffers')` to `require('buffers')` so when using `ImageStream` it works correctly.
