### PR TITLE
Fix travis.yml to run with correct Node.js version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-   - 0.6
-   - 0.8
-   - 0.10
+   - "0.6"
+   - "0.8"
+   - "0.10"
 
 before_install:
   - sudo apt-get update


### PR DESCRIPTION
This changes the `.travis.yml` to use the correct Node.js version
by using strings as version numbers.

Relevant Travis CI documentation page: http://about.travis-ci.org/docs/user/languages/javascript-with-nodejs/#Choosing-Node-versions-to-test-against

Without using strings to specify the desired versions Travis CI
runs on Node.js 0.1 instead of 0.10.
