### PR TITLE
Smoke test now uses portable file path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ build
 node_modules
 npm-debug.log
 out*.jpg
+out*.png
 examples/*.avi

--- a/smoke/smoke.sh
+++ b/smoke/smoke.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+if [ ! -f smoke/smoketest.js ]; then
+	echo "Please run smoke test from the top-level folder of the repository." >&2
+	exit 1
+fi
+
 node-gyp build && echo '-- Compiled OK -- 
 
 ' && node  smoke/smoketest.js && echo '-- Smoke Done, running tests --

--- a/smoke/smoketest.js
+++ b/smoke/smoketest.js
@@ -20,7 +20,7 @@ cv.readImage("/Users/peterbraden/Downloads/orl_faces/s6/10.pgm", function(e, im)
 
 
 */
-cv.readImage("/Users/peterbraden/Desktop/repos/node-opencv/examples/mona.png", function(e, mat){
+cv.readImage("examples/mona.png", function(e, mat){
   var th = mat.threshold(200, 200, "Threshold to Zero Inverted");
   th.save('out.png')
 


### PR DESCRIPTION
Added a sanity check to ensure smoke.sh is run from the correct folder
and use a relative path to the mona image so it works on any system.

You won't believe how long I spent trying to debug why the smoke test was core dumping on my system, only to finally look inside smoketest.js and discover that it was simply failing to load a non-existent image. This should improve on that a little.

Looks like you've made one new release since your presentation at OS Bridge, I'll have to take a look.
