### PR TITLE
Enhance package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
     "vision",
     "quadrocopter"
   ],
-  "main": "./lib/opencv"
+  "main": "./lib/opencv",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peterbraden/node-opencv.git"
+  }
 }


### PR DESCRIPTION
I don’t know if `engine` was (or is) a valid way to specify the necessary node version but [npm’s documentation](https://npmjs.org/doc/json.html#engines) only lists the `engines` field and therefore I changed it. I also added a `license` field and the repository url which fixes #61.
