### PR TITLE
fix bug on end of sstream crash due to "has not method end()"

### DIFF
--- a/lib/opencv.js
+++ b/lib/opencv.js
@@ -77,6 +77,8 @@ cv.ImageStream = function(){
 util.inherits(cv.ImageStream, Stream);
 var imagestream = cv.ImageStream.prototype;
 
+imagestream.end = function() {};
+
 imagestream.write = function(buf){
 	var self = this;
 	cv.readImage(buf, function(err, matrix){


### PR DESCRIPTION
I was experiencing an error using stream on missing method end, in this way we avoid that.

hope this helps.