### PR TITLE
Compute the moments of a contour

### DIFF
--- a/examples/contours.js
+++ b/examples/contours.js
@@ -7,7 +7,7 @@ var maxArea = 2500;
 
 var GREEN = [0, 255, 0]; //B, G, R
 var WHITE = [255, 255, 255]; //B, G, R
-
+var RED   = [0, 0, 255]; //B, G, R
 
 cv.readImage('./stuff.png', function(err, im) {
 
@@ -24,7 +24,12 @@ cv.readImage('./stuff.png', function(err, im) {
 
 	for(i = 0; i < contours.size(); i++) {
 		if(contours.area(i) > maxArea) {
+			var moments = contours.moments(i);
+			var cgx = Math.round(moments.m10/moments.m00);
+			var cgy = Math.round(moments.m01/moments.m00);
 			big.drawContour(contours, i, GREEN);
+			big.line([cgx - 5, cgy], [cgx + 5, cgy], RED);
+			big.line([cgx, cgy - 5], [cgx, cgy + 5], RED);
 		}
 	}
 

--- a/src/Contours.cc
+++ b/src/Contours.cc
@@ -33,6 +33,7 @@ Contour::Init(Handle<Object> target) {
 	NODE_SET_PROTOTYPE_METHOD(constructor, "boundingRect", BoundingRect);
 	NODE_SET_PROTOTYPE_METHOD(constructor, "minAreaRect", BoundingRect);
 	NODE_SET_PROTOTYPE_METHOD(constructor, "isConvex", IsConvex);
+	NODE_SET_PROTOTYPE_METHOD(constructor, "moments", Moments);
 	target->Set(String::NewSymbol("Contours"), m->GetFunction());
 };
 
@@ -220,3 +221,24 @@ Contour::IsConvex(const Arguments &args) {
 
 	return scope.Close(Boolean::New(isContourConvex(cv::Mat(self->contours[pos]))));
 }
+
+Handle<Value>
+Contour::Moments(const Arguments &args) {
+	HandleScope scope;
+
+	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+	int pos = args[0]->NumberValue();
+
+	/// Get the moments
+	cv::Moments mu = moments( self->contours[pos], false );
+    
+	Local<Object> res = Object::New();
+
+	res->Set(String::NewSymbol("m00"), Number::New(mu.m00));
+	res->Set(String::NewSymbol("m10"), Number::New(mu.m10));
+	res->Set(String::NewSymbol("m01"), Number::New(mu.m01));
+	res->Set(String::NewSymbol("m11"), Number::New(mu.m11));
+
+	return scope.Close(res);
+}
+

--- a/src/Contours.h
+++ b/src/Contours.h
@@ -24,5 +24,6 @@ class Contour: public node::ObjectWrap {
 	static Handle<Value> BoundingRect(const v8::Arguments&);
 	static Handle<Value> MinAreaRect(const v8::Arguments&);
 	static Handle<Value> IsConvex(const v8::Arguments&);
+	static Handle<Value> Moments(const v8::Arguments&);
 };
 


### PR DESCRIPTION
Added a moments method to the contour object and an example using resulting moments to display a cross at the "center of gravity" of a contour.
