### PR TITLE
Adding method pushBack for Matrices

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -96,6 +96,8 @@ Matrix::Init(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(constructor, "matchTemplate", MatchTemplate);
   NODE_SET_PROTOTYPE_METHOD(constructor, "minMaxLoc", MinMaxLoc);
 
+  NODE_SET_PROTOTYPE_METHOD(constructor, "pushBack", PushBack);
+
 	NODE_SET_METHOD(constructor, "Eye", Eye);
 
 
@@ -1632,4 +1634,20 @@ Matrix::MinMaxLoc(const v8::Arguments& args) {
   result->Set(String::NewSymbol("maxLoc"), o_maxLoc);
 
   return scope.Close(result);
+}
+
+
+// @author ytham
+// Pushes some matrix (argument) the back of a matrix (self)
+Handle<Value>
+Matrix::PushBack(const v8::Arguments& args) {
+  HandleScope scope;
+
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+
+  Matrix *m_input = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+
+  self->mat.push_back(m_input->mat);
+
+  return scope.Close(args.This());
 }

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -88,6 +88,8 @@ class Matrix: public node::ObjectWrap {
 
     JSFUNC(MatchTemplate)
     JSFUNC(MinMaxLoc)
+
+    JSFUNC(PushBack)
 /*
 	static Handle<Value> Val(const Arguments& args);
 	static Handle<Value> RowRange(const Arguments& args);


### PR DESCRIPTION
Adding the method pushBack that can be applied to a Matrix.  It is useful for some ML library methods.  The method wraps the push_back method in OpenCV and appends the bottom rows of the input matrix with the specified matrix.  Rows do not need to match, but columns and type must match.

Usage:
inputMatrix.pushBack(appendMatrix);

Example:
var a = new cv.Matrix(150, 64);
var b = new cv.Matrix(101, 64);
console.log("a: " + a.height() + ", " + a.width());  // a: 150, 64
console.log("b: " + b.height() + ", " + b.width());  // b: 101, 64

a.pushBack(b);
console.log("a: " + a.height() + ", " + a.width());  // a: 251, 64
