### PR TITLE
Added medianBlur and bilateralFilter

### DIFF
--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -48,6 +48,8 @@ class Matrix: public node::ObjectWrap {
     JSFUNC(ConvertGrayscale)
     JSFUNC(ConvertHSVscale)
     JSFUNC(GaussianBlur)
+    JSFUNC(MedianBlur)
+    JSFUNC(BilateralFilter)
     JSFUNC(Copy)
     JSFUNC(Flip)
     JSFUNC(ROI)


### PR DESCRIPTION
medianBlur and bilateralFilter are useful for various image filtering applications.  Usage:

img.medianBlur(blurValue);
img.bilateralFilter(d, sigmaColor, sigmaSpace [,borderType]); 

See the docs for more information on these filters:
http://docs.opencv.org/modules/imgproc/doc/filtering.html
