### PR TITLE
rectangle function utilizes two cvpoints that are top-left, bottom-right

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -605,7 +605,7 @@ Matrix::Rectangle(const Arguments& args) {
 		if(args[3]->IntegerValue())
 			thickness = args[3]->IntegerValue();
 
-		cv::rectangle(self->mat, cv::Point(x, y), cv::Point(width, height), color, thickness);
+		cv::rectangle(self->mat, cv::Point(x, y), cv::Point(x+width, y+height), color, thickness);
 	}
 
 	return scope.Close(v8::Null());


### PR DESCRIPTION
cv::rectangle is defined by two vertices, not one point and height/width.  Fixing this.

http://docs.opencv.org/modules/core/doc/drawing_functions.html#rectangle
