### PR TITLE
add shift image entry

### DIFF
--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -102,6 +102,7 @@ class Matrix: public node::ObjectWrap {
     JSFUNC(CopyWithMask)
     JSFUNC(SetWithMask)
     JSFUNC(MeanWithMask)
+    JSFUNC(Shift)
 /*
     static Handle<Value> Val(const Arguments& args);
     static Handle<Value> RowRange(const Arguments& args);


### PR DESCRIPTION
Shifts an image by an integer number of pixels x or y directions, with
a BORDER_REPLICATE fill.  uses the underlying copymakeborder opencv call.
