### PR TITLE
Added AdaptiveEqualizeHist

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -92,7 +92,8 @@ Matrix::Init(Handle<Object> target) {
 	NODE_SET_PROTOTYPE_METHOD(constructor, "cvtColor", CvtColor);
 	NODE_SET_PROTOTYPE_METHOD(constructor, "split", Split);
 	NODE_SET_PROTOTYPE_METHOD(constructor, "merge", Merge);
-	NODE_SET_PROTOTYPE_METHOD(constructor, "equalizeHist", EqualizeHist);
+  NODE_SET_PROTOTYPE_METHOD(constructor, "equalizeHist", EqualizeHist);
+	NODE_SET_PROTOTYPE_METHOD(constructor, "adaptiveEqualizeHist", AdaptiveEqualizeHist);
 
 	NODE_SET_PROTOTYPE_METHOD(constructor, "floodFill", FloodFill);
 
@@ -1670,6 +1671,27 @@ Matrix::EqualizeHist(const v8::Arguments& args) {
     Matrix * self = ObjectWrap::Unwrap<Matrix>(args.This());
 
     cv::equalizeHist(self->mat, self->mat);
+
+    return scope.Close(Undefined());
+}
+
+// @author dbousamra
+// Equalizes histogram using CLAHE
+// img.adaptiveEqualizeHist()
+Handle<Value>
+Matrix::AdaptiveEqualizeHist(const v8::Arguments& args) {
+    HandleScope scope;
+    
+    Matrix * self = ObjectWrap::Unwrap<Matrix>(args.This());
+    int clipLimit = args[0]->IntegerValue();
+    Local<Object> tileGridSize = args[1]->ToObject();
+    int width  = tileGridSize->Get(0)->IntegerValue();
+    int height = tileGridSize->Get(1)->IntegerValue();
+    
+    cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE();
+    clahe->setClipLimit(clipLimit);
+    clahe->setTilesGridSize(cv::Size(width, 5));
+    clahe->apply(self->mat, self->mat);
 
     return scope.Close(Undefined());
 }

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -87,6 +87,7 @@ class Matrix: public node::ObjectWrap {
     JSFUNC(Split)
     JSFUNC(Merge)
     JSFUNC(EqualizeHist)
+    JSFUNC(AdaptiveEqualizeHist)
     JSFUNC(Pixel)
     JSFUNC(FloodFill)
 


### PR DESCRIPTION
Added an adaptiveEqualizeHist method that uses the CLAHE methods in openCV. I didn't expose the CLAHE stuff, instead I did it all in one.