### PR TITLE
Added a delete for the matrix - Issue 101

### DIFF
--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -178,6 +178,7 @@ void AfterAsyncRead(uv_work_t *req) {
 	baton->cb->Call(Context::GetCurrent()->Global(), 2, argv);
 	baton->cb.Dispose();
 
+		delete baton->im;
 		delete baton;
 
 }


### PR DESCRIPTION
Needed since VideoCaptureWrap::Read(const Arguments &args) doesn't 

delete baton->im = new Matrix(); 
