### PR TITLE
Template matches

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -1719,26 +1719,11 @@ Matrix::FloodFill(const Arguments& args){
 	return scope.Close(Number::New( ret ));
 }
 
-
 // @author ytham
 // Match Template filter
-// Usage: output = input.matchTemplate("templateFileString", method);
+// Usage: output = input.matchTemplate(templateMatrix, method);
 Handle<Value>
 Matrix::MatchTemplate(const v8::Arguments& args) {
-  HandleScope scope;
-
-  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-
-  v8::String::Utf8Value args0(args[0]->ToString());
-  std::string filename = std::string(*args0);
-  cv::Mat templ;
-  templ = cv::imread(filename, CV_8S);
-
-  Local<Object> out = Matrix::constructor->GetFunction()->NewInstance();
-  Matrix *m_out = ObjectWrap::Unwrap<Matrix>(out);
-  int cols = self->mat.cols - templ.cols + 1;
-  int rows = self->mat.rows - templ.rows + 1;
-  m_out->mat.create(cols, rows, CV_32FC1);
 
   /*
     TM_SQDIFF        =0
@@ -1748,16 +1733,24 @@ Matrix::MatchTemplate(const v8::Arguments& args) {
     TM_CCOEFF        =4
     TM_CCOEFF_NORMED =5
   */
+   
+  HandleScope scope;
+
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *templ = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+
+  Local<Object> out = Matrix::constructor->GetFunction()->NewInstance();
+  Matrix *m_out = ObjectWrap::Unwrap<Matrix>(out);
+  int cols = self->mat.cols - templ->mat.cols + 1;
+  int rows = self->mat.rows - templ->mat.rows + 1;
+  m_out->mat.create(cols, rows, CV_32FC1);
+
   int method = (args.Length() < 2) ? (int)cv::TM_CCORR_NORMED : args[1]->Uint32Value();
 
-  cv::matchTemplate(self->mat, templ, m_out->mat, method);
-
-  double minVal; double maxVal; cv::Point minLoc; cv::Point maxLoc;
-  cv::minMaxLoc(m_out->mat, &minVal, &maxVal, &minLoc, &maxLoc, cv::Mat() );
+  cv::matchTemplate(self->mat, templ->mat, m_out->mat, method);
 
   return scope.Close(out);
 }
-
 
 // @author ytham
 // Min/Max location

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -96,7 +96,8 @@ Matrix::Init(Handle<Object> target) {
 
 	NODE_SET_PROTOTYPE_METHOD(constructor, "floodFill", FloodFill);
 
-	NODE_SET_PROTOTYPE_METHOD(constructor, "matchTemplate", MatchTemplate);
+  NODE_SET_PROTOTYPE_METHOD(constructor, "matchTemplate", MatchTemplate);
+  NODE_SET_PROTOTYPE_METHOD(constructor, "templateMatches", TemplateMatches);
 	NODE_SET_PROTOTYPE_METHOD(constructor, "minMaxLoc", MinMaxLoc);
 
 	NODE_SET_PROTOTYPE_METHOD(constructor, "pushBack", PushBack);
@@ -1717,6 +1718,87 @@ Matrix::FloodFill(const Arguments& args){
 
 
 	return scope.Close(Number::New( ret ));
+}
+
+// @author olfox
+// Returns an array of the most probable positions
+// Usage: output = input.templateMatches(min_probability, max_probability, limit, ascending, min_x_distance, min_y_distance);
+Handle<Value>
+Matrix::TemplateMatches(const v8::Arguments& args) {
+  HandleScope scope;
+
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+
+  bool filter_min_probability = (args.Length() >= 1) ? args[0]->IsNumber() : false;
+  bool filter_max_probability = (args.Length() >= 2) ? args[1]->IsNumber() : false;
+  double min_probability = filter_min_probability ? args[0]->NumberValue() : 0;
+  double max_probability = filter_max_probability ? args[1]->NumberValue() : 0;
+  int limit = (args.Length() >= 3) ? args[2]->IntegerValue() : 0;
+  bool ascending = (args.Length() >= 4) ? args[3]->BooleanValue() : false;
+  int min_x_distance = (args.Length() >= 5) ? args[4]->IntegerValue() : 0;
+  int min_y_distance = (args.Length() >= 6) ? args[5]->IntegerValue() : 0;
+
+  cv::Mat_<int> indices;
+
+  if (ascending)
+    cv::sortIdx(self->mat.reshape(0,1), indices, CV_SORT_ASCENDING + CV_SORT_EVERY_ROW);
+  else
+    cv::sortIdx(self->mat.reshape(0,1), indices, CV_SORT_DESCENDING + CV_SORT_EVERY_ROW);
+
+  cv::Mat hit_mask = cv::Mat::zeros(self->mat.size(), CV_64F);
+  v8::Local<v8::Array> probabilites_array = v8::Array::New();
+
+  cv::Mat_<float>::const_iterator begin = self->mat.begin<float>();
+  cv::Mat_<int>::const_iterator it = indices.begin();
+  cv::Mat_<int>::const_iterator end = indices.end();
+  int index = 0;
+  for (; (limit == 0 || index < limit) && it != end; ++it) {
+    cv::Point pt = (begin + *it).pos();
+
+    float probability = self->mat.at<float>(pt.y, pt.x);
+
+    if (filter_min_probability && probability < min_probability) {
+      if (ascending) continue;
+      else break;
+    }
+
+    if (filter_max_probability && probability > max_probability) {
+      if (ascending) break;
+      else continue;
+    }
+
+    if (min_x_distance != 0 || min_y_distance != 0) {
+      // Check hit mask color for for every corner
+
+      cv::Size maxSize = hit_mask.size();
+      int max_x = maxSize.width - 1;
+      int max_y = maxSize.height - 1;
+      cv::Point top_left = cv::Point(max(0, pt.x - min_x_distance), max(0, pt.y - min_y_distance));
+      cv::Point top_right = cv::Point(min(max_x, pt.x + min_x_distance), max(0, pt.y - min_y_distance));
+      cv::Point bottom_left = cv::Point(max(0, pt.x - min_x_distance), min(max_y, pt.y + min_y_distance));
+      cv::Point bottom_right = cv::Point(min(max_x, pt.x + min_x_distance), min(max_y, pt.y + min_y_distance));
+      if (hit_mask.at<double>(top_left.y, top_left.x) > 0) continue;
+      if (hit_mask.at<double>(top_right.y, top_right.x) > 0) continue;
+      if (hit_mask.at<double>(bottom_left.y, bottom_left.x) > 0) continue;
+      if (hit_mask.at<double>(bottom_right.y, bottom_right.x) > 0) continue;
+      cv::Scalar color(255.0);
+      cv::rectangle(hit_mask, top_left, bottom_right, color, CV_FILLED);
+    }
+
+    Local<Value> x_value = v8::Number::New(pt.x);
+    Local<Value> y_value = v8::Number::New(pt.y);
+    Local<Value> probability_value = v8::Number::New(probability);
+
+    Local<Object> probability_object = Object::New();
+    probability_object->Set(String::NewSymbol("x"), x_value);
+    probability_object->Set(String::NewSymbol("y"), y_value);
+    probability_object->Set(String::NewSymbol("probability"), probability_value);
+
+    probabilites_array->Set(index, probability_object);
+    index++;
+  }
+
+  return scope.Close(probabilites_array);
 }
 
 // @author ytham

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -91,6 +91,7 @@ class Matrix: public node::ObjectWrap {
     JSFUNC(FloodFill)
 
     JSFUNC(MatchTemplate)
+    JSFUNC(TemplateMatches)
     JSFUNC(MinMaxLoc)
 
     JSFUNC(PushBack)


### PR DESCRIPTION
This adds a method called TemplateMatches(maybe there is a better name?) that performs some actions with the matrix returned by MatchTemplate. For one it sorts it by asc/desc probability and creates a array with { x, y, probability }-objects so that you can easily iterate over it on the JS side. But due to the nature of MatchTemplate that array can get super big so I added a min/max probability filter and a neighbour filter.

The neighbour filter works by creating a new 1 ch matrix filled with 0s the size of the match matrix. For every match it draws a rectangle centered on the position with the size of (min_x_distance * 2, min_y_distance * 2). New matches are only added if its corresponding rectangle is to occupy a space with 0s. I.e., it is a hit mask. Since the matches are already sorted in order of of most probable only the best match in area will be returned.

I dont know how this fits into this framework, but it sure helped me alot so i thought i would at least send it in :)

Gr8 work btw! (again: _review_, rusty c++ skills)