### PR TITLE
Use this.emit(‘error’) in streams

### DIFF
--- a/lib/opencv.js
+++ b/lib/opencv.js
@@ -65,6 +65,7 @@ ImageDataStream.prototype.end = function(b){
 
   var buf = this.data.toBuffer();
   cv.readImage(buf, function(err, im){
+    if (err) return self.emit('error', err);
     self.emit('load', im);
   });
 }
@@ -83,7 +84,7 @@ util.inherits(ObjectDetectionStream, Stream);
 ObjectDetectionStream.prototype.write = function(m){
   var self = this;
   this.classifier.detectMultiScale(m, function(err, objs){
-    if (err) throw err;
+    if (err) return self.emit('error', err);
     self.emit('data', objs, m);
   }
   , this.opts.scale


### PR DESCRIPTION
Also prettify the js file.
There was a mix between spaces and tabs.
We probably should have more test.
