### PR TITLE
fixes to Matrix.cc: findContours(), bitwiseAnd(), bitwiseNot(), bitwiseXor(); houghCircles() has been added;

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -68,6 +68,7 @@ Matrix::Init(Handle<Object> target) {
 	NODE_SET_PROTOTYPE_METHOD(ctor, "drawAllContours", DrawAllContours);
 	NODE_SET_PROTOTYPE_METHOD(ctor, "goodFeaturesToTrack", GoodFeaturesToTrack);
 	NODE_SET_PROTOTYPE_METHOD(ctor, "houghLinesP", HoughLinesP);
+	NODE_SET_PROTOTYPE_METHOD(ctor, "houghCircles", HoughCircles);
 	NODE_SET_PROTOTYPE_METHOD(ctor, "inRange", inRange);
 	NODE_SET_PROTOTYPE_METHOD(ctor, "adjustROI", AdjustROI);
 	NODE_SET_PROTOTYPE_METHOD(ctor, "locateROI", LocateROI);
@@ -1250,6 +1251,41 @@ NAN_METHOD(Matrix::HoughLinesP) {
     pt->Set(1, NanNew<Number>((double) lines[i][1]));
     pt->Set(2, NanNew<Number>((double) lines[i][2]));
     pt->Set(3, NanNew<Number>((double) lines[i][3]));
+    arr->Set(i, pt);
+  }
+
+  NanReturnValue(arr);
+
+}
+
+NAN_METHOD(Matrix::HoughCircles) {
+	NanScope();
+
+	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+
+  double dp = args.Length() < 1 ? 1 : args[0]->NumberValue();
+  double minDist = args.Length() < 2 ? 1 : args[1]->NumberValue();
+  double higherThreshold = args.Length() < 3 ? 100 : args[2]->NumberValue();
+  double accumulatorThreshold = args.Length() < 4 ? 100 : args[3]->NumberValue();
+  int minRadius = args.Length() < 5 ? 0 : args[4]->Uint32Value();
+  int maxRadius = args.Length() < 6 ? 0 : args[5]->Uint32Value();
+  std::vector<cv::Vec3f> circles;
+
+  cv::Mat gray;
+
+
+  equalizeHist(self->mat, gray);
+  
+  cv::HoughCircles(gray, circles, CV_HOUGH_GRADIENT, dp, minDist, higherThreshold, accumulatorThreshold, minRadius, maxRadius);
+
+  v8::Local<v8::Array> arr = NanNew<Array>(circles.size());
+
+
+  for (unsigned int i=0; i < circles.size(); i++){
+    v8::Local<v8::Array> pt = NanNew<Array>(3);
+    pt->Set(0, NanNew<Number>((double) circles[i][0]));// center x
+    pt->Set(1, NanNew<Number>((double) circles[i][1]));// center y
+    pt->Set(2, NanNew<Number>((double) circles[i][2]));// radius
     arr->Set(i, pt);
   }
 

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -74,6 +74,7 @@ class Matrix: public node::ObjectWrap {
     // Feature Detection
     JSFUNC(GoodFeaturesToTrack)
     JSFUNC(HoughLinesP)
+    JSFUNC(HoughCircles)
 
     JSFUNC(Crop)
 


### PR DESCRIPTION
- findContours() fixed as it was always returning 0 before
- bitwiseAnd(), bitwiseNot(), bitwiseXor() may accept mask as the last argument since now
- houghCircles() method added
