### PR TITLE
Add pre compiled binaries for windows, mac and linux

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,8 +59,7 @@ before_build:
 # to run your custom scripts instead of automatic MSBuild
 build_script:
   - cmd: ECHO "BUILDING x64 binary package:"
-  #- cmd: npm install --build-from-source --msvs_version=2013
-  - cmd: npm install --msvs_version=2013
+  - cmd: npm install --build-from-source --msvs_version=2013
   - cmd: npm test
   - cmd: node lib/opencv.js
   - cmd: ECHO "PUBLISH x64 binary package:"
@@ -82,8 +81,7 @@ after_build:
   - cmd: npm install -g node-gyp
   - cmd: copy .\utils\opencv_x86.pc C:\GTK\lib\pkgconfig\opencv.pc
   - cmd: ECHO "BUILDING x86 binary package:"
-  #- cmd: npm install --build-from-source --msvs_version=2013
-  - cmd: npm install --msvs_version=2013
+  - cmd: npm install --build-from-source --msvs_version=2013
   - cmd: npm test
   - cmd: node lib/opencv.js
   - cmd: ECHO "PUBLISH x86 binary package:"


### PR DESCRIPTION
Adds pre compiled binaries for all 3 major platforms using node-pre-gyp. This is the same thing we did and are using in node-serialport, has worked great so far.

@peterbraden after merging I do need your help to generate the secure keys in travis and app-veyor (since they are repo and account bound respectively). We also need to create a new branch for OSX pre-compiled binaries called `osx-binaries`, since travis does not support multiple OS builds, so we need a different branch to compile for OSX.

I'm creating a pre-compiled-binaries.md file to describe the process, I'll also add a make task to make it easier to generate the binaries with each release.

BTW we at [The Hybrid Group](https://github.com/hybridgroup) ([hybridgroup.com](http://hybridgroup.com/)) are sponsoring the AS3 buckets, we also do it for node-serialport (as mentioned above) and we'll be adding them for [node-gamepad](https://github.com/creationix/node-gamepad).

Regards,