### PR TITLE
fixed Matrix Crop prototype

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -32,6 +32,7 @@ Matrix::Init(Handle<Object> target) {
 	NODE_SET_PROTOTYPE_METHOD(ctor, "height", Height);
 	NODE_SET_PROTOTYPE_METHOD(ctor, "size", Size);
 	NODE_SET_PROTOTYPE_METHOD(ctor, "clone", Clone);
+	NODE_SET_PROTOTYPE_METHOD(ctor, "crop", Crop);
 	NODE_SET_PROTOTYPE_METHOD(ctor, "toBuffer", ToBuffer);
 	NODE_SET_PROTOTYPE_METHOD(ctor, "toBufferAsync", ToBufferAsync);
 	NODE_SET_PROTOTYPE_METHOD(ctor, "ellipse", Ellipse);


### PR DESCRIPTION
Maybe this was intentionally left out ?
The matrix crop method didn't work anymore. Easy fix.
