### PR TITLE
Added Camera Calibration Functions

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,6 +14,7 @@
         , "src/FaceRecognizer.cc"
         , "src/BackgroundSubtractor.cc"
         , "src/Constants.cc"
+        , "src/Calib3D.cc"
         ]
       , 'libraries': [
           '<!@(pkg-config --libs opencv)'

--- a/src/Calib3D.cc
+++ b/src/Calib3D.cc
@@ -8,6 +8,7 @@ void Calib3D::Init(Handle<Object> target)
     NanAssignPersistent(inner, obj);
 
     NODE_SET_METHOD(obj, "findChessboardCorners", FindChessboardCorners);
+    NODE_SET_METHOD(obj, "drawChessboardCorners", DrawChessboardCorners);
 
     target->Set(NanNew("calib3d"), obj);
 }
@@ -86,3 +87,72 @@ NAN_METHOD(Calib3D::FindChessboardCorners)
     }
 
 };
+
+// cv::drawChessboardCorners
+NAN_METHOD(Calib3D::DrawChessboardCorners)
+{
+    NanEscapableScope();
+
+    try {
+        // Get the arguments
+
+        // Arg 0 is the image
+        Matrix* m = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+        cv::Mat mat = m->mat;
+
+        // Arg 1 is the pattern size
+        cv::Size patternSize;
+        if (args[1]->IsArray()) {
+            Local<Object> v8sz = args[1]->ToObject();
+
+            patternSize = cv::Size(v8sz->Get(0)->IntegerValue(), v8sz->Get(1)->IntegerValue());
+        } else {
+            JSTHROW_TYPE("Must pass pattern size");
+        }
+
+        // Arg 2 is the corners array
+        std::vector<cv::Point2f> corners;
+        if(args[2]->IsArray()) {
+            Local<Array> cornersArray = Local<Array>::Cast(args[2]);
+
+            for(unsigned int i = 0; i < cornersArray->Length(); i++)
+            {
+                Local<Object> pt = cornersArray->Get(i)->ToObject();
+                corners.push_back(cv::Point2f(pt->Get(NanNew<String>("x"))->ToNumber()->Value(),
+                                              pt->Get(NanNew<String>("y"))->ToNumber()->Value()));
+            }
+        } else {
+            JSTHROW_TYPE("Must pass corners array");
+        }
+
+        // Arg 3, pattern found boolean
+        bool patternWasFound = args[3]->ToBoolean()->Value();
+
+        // Final argument is the callback
+        REQ_FUN_ARG(4, cb);
+
+        // Draw the corners
+        cv::drawChessboardCorners(mat, patternSize, corners, patternWasFound);
+
+        // Make the callback arguments (same image that was passed, now with corners drawn on it)
+        Local<Value> argv[2];
+        argv[0] = NanNull();
+        argv[1] = args[0];
+
+        // Callback
+        TryCatch try_catch;
+
+        cb->Call(NanGetCurrentContext()->Global(), 2, argv);
+
+        if(try_catch.HasCaught()) {
+            FatalException(try_catch);
+        }
+
+        NanReturnUndefined();
+
+    } catch (cv::Exception &e) {
+        const char *err_msg = e.what();
+        NanThrowError(err_msg);
+        NanReturnUndefined();
+    }
+}

--- a/src/Calib3D.cc
+++ b/src/Calib3D.cc
@@ -1,0 +1,88 @@
+#include "Calib3D.h"
+#include "Matrix.h"
+
+void Calib3D::Init(Handle<Object> target)
+{
+    Persistent<Object> inner;
+    Local<Object> obj = NanNew<Object>();
+    NanAssignPersistent(inner, obj);
+
+    NODE_SET_METHOD(obj, "findChessboardCorners", FindChessboardCorners);
+
+    target->Set(NanNew("calib3d"), obj);
+}
+
+// cv::findChessboardCorners
+NAN_METHOD(Calib3D::FindChessboardCorners)
+{
+    NanEscapableScope();
+
+    try {
+        // Get the arguments from javascript
+
+        // Arg 0 is the image
+        Matrix* m = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+        cv::Mat mat = m->mat;
+
+        // Arg 1 is the pattern size
+        cv::Size patternSize;
+        if (args[1]->IsArray()) {
+            Local<Object> v8sz = args[1]->ToObject();
+
+            patternSize = cv::Size(v8sz->Get(0)->IntegerValue(), v8sz->Get(1)->IntegerValue());
+        } else {
+            JSTHROW_TYPE("Must pass pattern size");
+        }
+
+        // Arg 2 would normally be the flags, ignoring this for now and using the default flags
+
+        // Final argument is the callback function
+        REQ_FUN_ARG(2, cb);
+
+        // Find the corners
+        std::vector<cv::Point2f> corners;
+        bool found = cv::findChessboardCorners(mat, patternSize, corners);
+
+        // Make the callback arguments
+        Local<Value> argv[2];
+
+        argv[0] = NanNull();
+        argv[1] = NanNull(); // This will be replaced by the corners array if corners were found
+
+        // Further processing if we found corners
+        Local<Array> cornersArray;
+        if(found)
+        {
+            // Convert the return value to a javascript array
+            cornersArray = Array::New(corners.size());
+            for(unsigned int i = 0; i < corners.size(); i++)
+            {
+                Local<Object> point_data = NanNew<Object>();
+                point_data->Set(NanNew<String>("x"), NanNew<Number>(corners[i].x));
+                point_data->Set(NanNew<String>("y"), NanNew<Number>(corners[i].y));
+
+                cornersArray->Set(Number::New(i), point_data);
+            }
+
+            argv[1] = cornersArray;
+        }
+
+        // Callback
+        TryCatch try_catch;
+
+        cb->Call(NanGetCurrentContext()->Global(), 2, argv);
+
+        if(try_catch.HasCaught()) {
+            FatalException(try_catch);
+        }
+
+        NanReturnUndefined();
+
+
+    } catch (cv::Exception &e) {
+        const char *err_msg = e.what();
+        NanThrowError(err_msg);
+        NanReturnUndefined();
+    }
+
+};

--- a/src/Calib3D.cc
+++ b/src/Calib3D.cc
@@ -47,14 +47,14 @@ NAN_METHOD(Calib3D::FindChessboardCorners)
         Local<Object> ret = NanNew<Object>();
         ret->Set(NanNew<String>("found"), NanNew<Boolean>(found));
 
-        Local<Array> cornersArray = Array::New(corners.size());
+        Local<Array> cornersArray = NanNew<Array>(corners.size());
         for(unsigned int i = 0; i < corners.size(); i++)
         {
             Local<Object> point_data = NanNew<Object>();
             point_data->Set(NanNew<String>("x"), NanNew<Number>(corners[i].x));
             point_data->Set(NanNew<String>("y"), NanNew<Number>(corners[i].y));
 
-            cornersArray->Set(Number::New(i), point_data);
+            cornersArray->Set(NanNew<Number>(i), point_data);
         }
 
         ret->Set(NanNew<String>("corners"), cornersArray);

--- a/src/Calib3D.h
+++ b/src/Calib3D.h
@@ -14,6 +14,8 @@ public:
     static NAN_METHOD(DrawChessboardCorners);
 
     static NAN_METHOD(CalibrateCamera);
+
+    static NAN_METHOD(SolvePnP);
 };
 
 #endif

--- a/src/Calib3D.h
+++ b/src/Calib3D.h
@@ -1,0 +1,15 @@
+#ifndef __NODE_CALIB3D_H
+#define __NODE_CALIB3D_H
+
+#include "OpenCV.h"
+
+// Implementation of calib3d.hpp functions
+
+class Calib3D: public node::ObjectWrap {
+public:
+    static void Init(Handle<Object> target);
+
+    static NAN_METHOD(FindChessboardCorners);
+};
+
+#endif

--- a/src/Calib3D.h
+++ b/src/Calib3D.h
@@ -12,6 +12,8 @@ public:
     static NAN_METHOD(FindChessboardCorners);
 
     static NAN_METHOD(DrawChessboardCorners);
+
+    static NAN_METHOD(CalibrateCamera);
 };
 
 #endif

--- a/src/Calib3D.h
+++ b/src/Calib3D.h
@@ -10,6 +10,8 @@ public:
     static void Init(Handle<Object> target);
 
     static NAN_METHOD(FindChessboardCorners);
+
+    static NAN_METHOD(DrawChessboardCorners);
 };
 
 #endif

--- a/src/OpenCV.cc
+++ b/src/OpenCV.cc
@@ -12,8 +12,6 @@ OpenCV::Init(Handle<Object> target) {
   target->Set(NanNew<String>("version"), NanNew<String>(out, n));
 
   NODE_SET_METHOD(target, "readImage", ReadImage);
-  NODE_SET_METHOD(target, "findChessboardCorners", FindChessboardCorners);
-
 }
 
 
@@ -75,77 +73,4 @@ NAN_METHOD(OpenCV::ReadImage) {
       NanThrowError(err_msg);
       NanReturnUndefined();
   }
-};
-
-NAN_METHOD(OpenCV::FindChessboardCorners) {
-    NanEscapableScope();
-
-    try {
-        // Get the arguments from javascript
-
-        // Arg 0 is the image
-        Matrix* m = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-        cv::Mat mat = m->mat;
-
-        // Arg 1 is the pattern size
-        cv::Size patternSize;
-        if (args[1]->IsArray()) {
-            Local<Object> v8sz = args[1]->ToObject();
-
-            patternSize = cv::Size(v8sz->Get(0)->IntegerValue(), v8sz->Get(1)->IntegerValue());
-        } else {
-            JSTHROW_TYPE("Must pass pattern size");
-        }
-
-        // Arg 2 would normally be the flags, ignoring this for now and using the default flags
-
-        // Final argument is the callback function
-        REQ_FUN_ARG(2, cb);
-
-        // Find the corners
-        std::vector<cv::Point2f> corners;
-        bool found = cv::findChessboardCorners(mat, patternSize, corners);
-
-        // Make the callback arguments
-        Local<Value> argv[2];
-
-        argv[0] = NanNull();
-        argv[1] = NanNull(); // This will be replaced by the corners array if corners were found
-
-        // Further processing if we found corners
-        Local<Array> cornersArray;
-        if(found)
-        {
-            // Convert the return value to a javascript array
-            cornersArray = Array::New(corners.size());
-            for(int i = 0; i < corners.size(); i++)
-            {
-                Local<Object> point_data = NanNew<Object>();
-                point_data->Set(NanNew<String>("x"), NanNew<Number>(corners[i].x));
-                point_data->Set(NanNew<String>("y"), NanNew<Number>(corners[i].y));
-
-                cornersArray->Set(Number::New(i), point_data);
-            }
-
-            argv[1] = cornersArray;
-        }
-
-        // Callback
-        TryCatch try_catch;
-
-        cb->Call(NanGetCurrentContext()->Global(), 2, argv);
-
-        if(try_catch.HasCaught()) {
-            FatalException(try_catch);
-        }
-
-        NanReturnUndefined();
-
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
-
 };

--- a/src/OpenCV.cc
+++ b/src/OpenCV.cc
@@ -5,48 +5,49 @@
 void
 OpenCV::Init(Handle<Object> target) {
   NanScope();
-  
+
   // Version string.
   char out [21];
   int n = sprintf(out, "%i.%i", CV_MAJOR_VERSION, CV_MINOR_VERSION);
   target->Set(NanNew<String>("version"), NanNew<String>(out, n));
 
   NODE_SET_METHOD(target, "readImage", ReadImage);
+  NODE_SET_METHOD(target, "findChessboardCorners", FindChessboardCorners);
 
-}  
+}
 
 
 NAN_METHOD(OpenCV::ReadImage) {
   NanEscapableScope();
 
   try{
-    
+
     Local<Object> im_h = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
     Matrix *img = ObjectWrap::Unwrap<Matrix>(im_h);
-    
+
     cv::Mat mat;
 
     REQ_FUN_ARG(1, cb);
-    
+
     if (args[0]->IsNumber() && args[1]->IsNumber()){
       int width, height;
 
       width = args[0]->Uint32Value();
-      height = args[1]->Uint32Value();    
+      height = args[1]->Uint32Value();
       mat = *(new cv::Mat(width, height, CV_64FC1));
 
     } else if (args[0]->IsString()) {
-      
+
       std::string filename = std::string(*NanAsciiString(args[0]->ToString()));
       mat = cv::imread(filename);
 
     } else if (Buffer::HasInstance(args[0])){
      	uint8_t *buf = (uint8_t *) Buffer::Data(args[0]->ToObject());
      	unsigned len = Buffer::Length(args[0]->ToObject());
-      
+
   	 	cv::Mat *mbuf = new cv::Mat(len, 1, CV_64FC1, buf);
       mat = cv::imdecode(*mbuf, -1);
-            
+
       if (mat.empty()){
         NanThrowTypeError("Error loading file");
       }
@@ -74,4 +75,77 @@ NAN_METHOD(OpenCV::ReadImage) {
       NanThrowError(err_msg);
       NanReturnUndefined();
   }
-};    
+};
+
+NAN_METHOD(OpenCV::FindChessboardCorners) {
+    NanEscapableScope();
+
+    try {
+        // Get the arguments from javascript
+
+        // Arg 0 is the image
+        Matrix* m = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+        cv::Mat mat = m->mat;
+
+        // Arg 1 is the pattern size
+        cv::Size patternSize;
+        if (args[1]->IsArray()) {
+            Local<Object> v8sz = args[1]->ToObject();
+
+            patternSize = cv::Size(v8sz->Get(0)->IntegerValue(), v8sz->Get(1)->IntegerValue());
+        } else {
+            JSTHROW_TYPE("Must pass pattern size");
+        }
+
+        // Arg 2 would normally be the flags, ignoring this for now and using the default flags
+
+        // Final argument is the callback function
+        REQ_FUN_ARG(2, cb);
+
+        // Find the corners
+        std::vector<cv::Point2f> corners;
+        bool found = cv::findChessboardCorners(mat, patternSize, corners);
+
+        // Make the callback arguments
+        Local<Value> argv[2];
+
+        argv[0] = NanNull();
+        argv[1] = NanNull(); // This will be replaced by the corners array if corners were found
+
+        // Further processing if we found corners
+        Local<Array> cornersArray;
+        if(found)
+        {
+            // Convert the return value to a javascript array
+            cornersArray = Array::New(corners.size());
+            for(int i = 0; i < corners.size(); i++)
+            {
+                Local<Object> point_data = NanNew<Object>();
+                point_data->Set(NanNew<String>("x"), NanNew<Number>(corners[i].x));
+                point_data->Set(NanNew<String>("y"), NanNew<Number>(corners[i].y));
+
+                cornersArray->Set(Number::New(i), point_data);
+            }
+
+            argv[1] = cornersArray;
+        }
+
+        // Callback
+        TryCatch try_catch;
+
+        cb->Call(NanGetCurrentContext()->Global(), 2, argv);
+
+        if(try_catch.HasCaught()) {
+            FatalException(try_catch);
+        }
+
+        NanReturnUndefined();
+
+
+    } catch (cv::Exception &e) {
+        const char *err_msg = e.what();
+        NanThrowError(err_msg);
+        NanReturnUndefined();
+    }
+
+};

--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -50,8 +50,6 @@ class OpenCV: public node::ObjectWrap{
     static void Init(Handle<Object> target);
 
     static NAN_METHOD(ReadImage);
-
-    static NAN_METHOD(FindChessboardCorners);
 };
 
 

--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -50,9 +50,10 @@ class OpenCV: public node::ObjectWrap{
     static void Init(Handle<Object> target);
 
     static NAN_METHOD(ReadImage);
+
+    static NAN_METHOD(FindChessboardCorners);
 };
 
 
 
 #endif
-

--- a/src/init.cc
+++ b/src/init.cc
@@ -9,21 +9,22 @@
 #include "HighGUI.h"
 #include "FaceRecognizer.h"
 #include "Constants.h"
-
+#include "Calib3D.h"
 
 extern "C" void
 init(Handle<Object> target) {
     NanScope();
     OpenCV::Init(target);
-    
+
     Point::Init(target);
     Matrix::Init(target);
     CascadeClassifierWrap::Init(target);
     VideoCaptureWrap::Init(target);
     Contour::Init(target);
-	  TrackedObject::Init(target);
+	TrackedObject::Init(target);
     NamedWindow::Init(target);
     Constants::Init(target);
+    Calib3D::Init(target);
 
 
    #if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4


### PR DESCRIPTION
I have added the basic camera calibration functions, that is the following 4 functions that I considered the minimum set for performing camera calibration

* `findChessboardCorners`
* `drawChessboardCorners`
* `calibrateCamera`
* `solvePnP`

A couple of notes

1. I tried to keep the coding style consistent with the rest of your work, if something seems wrong let me know and I'll withdraw the pull request and fix it.
2. Since these processes are synchronous, I wrote them as synchronous methods with return values. I noticed that in a lot of cases, you use callbacks even for synchronous code. If that is important, let me know and I'll withdraw the pull request and change each function to use callbacks.
3. I added these files in a new `Calib3D` file to keep the C++ codebase organized and I added the new object `cv.calib3d` to group the functions in the same way that C++ OpenCV groups them into headers. If you'd rather they all be accessible under the `cv` object, let me know and I'll change it (in all cases, the `cv` object is the one you get when `require('opencv')` is called.
4. I skipped all of the `flags` and `TermCriteria` arguments opting for the default, I do plan to add them back in later.
5. I would have liked to add `undistort` as well but it is under the `imgproc` header so I'm waiting on that one to see if I need to add an `ImgProc` source file for it.