### PR TITLE
Make node-opencv compile against OpenCV 3.0.0

### DIFF
--- a/src/Calib3D.h
+++ b/src/Calib3D.h
@@ -3,7 +3,9 @@
 
 #include "OpenCV.h"
 
+#if CV_MAJOR_VERSION >= 3
 #include <opencv2/calib3d.hpp>
+#endif
 
 // Implementation of calib3d.hpp functions
 

--- a/src/Calib3D.h
+++ b/src/Calib3D.h
@@ -3,6 +3,8 @@
 
 #include "OpenCV.h"
 
+#include <opencv2/calib3d.hpp>
+
 // Implementation of calib3d.hpp functions
 
 class Calib3D: public node::ObjectWrap {

--- a/src/CamShift.cc
+++ b/src/CamShift.cc
@@ -2,6 +2,7 @@
 #include "OpenCV.h"
 #include "Matrix.h"
 
+#include <opencv2/video/tracking.hpp>
 
 #define CHANNEL_HUE 0
 #define CHANNEL_SATURATION 1

--- a/src/CamShift.cc
+++ b/src/CamShift.cc
@@ -2,7 +2,9 @@
 #include "OpenCV.h"
 #include "Matrix.h"
 
+#if CV_MAJOR_VERSION >= 3
 #include <opencv2/video/tracking.hpp>
+#endif
 
 #define CHANNEL_HUE 0
 #define CHANNEL_SATURATION 1

--- a/src/CascadeClassifierWrap.cc
+++ b/src/CascadeClassifierWrap.cc
@@ -4,6 +4,11 @@
 #include <nan.h>
 
 
+#include <opencv2/objdetect.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+
+
 Persistent<FunctionTemplate> CascadeClassifierWrap::constructor;
 
 void

--- a/src/CascadeClassifierWrap.cc
+++ b/src/CascadeClassifierWrap.cc
@@ -3,11 +3,11 @@
 #include "Matrix.h"
 #include <nan.h>
 
-
+#if CV_MAJOR_VERSION >= 3
 #include <opencv2/objdetect.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/imgcodecs.hpp>
-
+#endif
 
 Persistent<FunctionTemplate> CascadeClassifierWrap::constructor;
 

--- a/src/CascadeClassifierWrap.h
+++ b/src/CascadeClassifierWrap.h
@@ -1,4 +1,5 @@
 #include "OpenCV.h"
+#include <opencv2/objdetect.hpp>
 
 class CascadeClassifierWrap: public node::ObjectWrap {
   public: 

--- a/src/CascadeClassifierWrap.h
+++ b/src/CascadeClassifierWrap.h
@@ -1,5 +1,8 @@
 #include "OpenCV.h"
+
+#if CV_MAJOR_VERSION >= 3
 #include <opencv2/objdetect.hpp>
+#endif
 
 class CascadeClassifierWrap: public node::ObjectWrap {
   public: 

--- a/src/Contours.cc
+++ b/src/Contours.cc
@@ -4,6 +4,8 @@
 
 #include <iostream>
 
+#include <opencv2/imgproc.hpp>
+
 v8::Persistent<FunctionTemplate> Contour::constructor;
 
 

--- a/src/Contours.cc
+++ b/src/Contours.cc
@@ -4,7 +4,6 @@
 
 #include <iostream>
 
-#include <opencv2/imgproc.hpp>
 
 v8::Persistent<FunctionTemplate> Contour::constructor;
 

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -3,10 +3,10 @@
 #include "OpenCV.h"
 #include <nan.h>
 
-#include <opencv2/core.hpp>
-#include <opencv2/imgproc.hpp>
+#if CV_MAJOR_VERSION >= 3
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/ml.hpp>
+#endif
 
 v8::Persistent<FunctionTemplate> Matrix::constructor;
 

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -3,6 +3,11 @@
 #include "OpenCV.h"
 #include <nan.h>
 
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/ml.hpp>
+
 v8::Persistent<FunctionTemplate> Matrix::constructor;
 
 cv::Scalar setColor(Local<Object> objColor);

--- a/src/OpenCV.cc
+++ b/src/OpenCV.cc
@@ -2,9 +2,10 @@
 #include "Matrix.h"
 #include <nan.h>
 
-#include <opencv2/core.hpp>
-#include <opencv2/imgproc.hpp>
+
+#if CV_MAJOR_VERSION >= 3
 #include <opencv2/imgcodecs.hpp>
+#endif
 
 void
 OpenCV::Init(Handle<Object> target) {

--- a/src/OpenCV.cc
+++ b/src/OpenCV.cc
@@ -2,6 +2,10 @@
 #include "Matrix.h"
 #include <nan.h>
 
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+
 void
 OpenCV::Init(Handle<Object> target) {
   NanScope();

--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -7,9 +7,11 @@
 #include <node_version.h>
 #include <node_buffer.h>
 #include <opencv/cv.h>
+#if CV_MAJOR_VERSION >= 3
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/videoio.hpp>
+#endif
 #include <string.h>
 #include <nan.h>
 

--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -7,7 +7,9 @@
 #include <node_version.h>
 #include <node_buffer.h>
 #include <opencv/cv.h>
-#include <opencv/highgui.h>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
 #include <string.h>
 #include <nan.h>
 

--- a/src/Stereo.cc
+++ b/src/Stereo.cc
@@ -1,8 +1,12 @@
 #include "Stereo.h"
 #include "Matrix.h"
-//#include <opencv2/legacy.hpp>
-#include <opencv2/ml.hpp>
+#if CV_MAJOR_VERSION < 3
+#include <opencv2/legacy.hpp>
+#endif
 
+#if CV_MAJOR_VERSION >= 3
+#include <opencv2/ml.hpp>
+#endif
 // Block matching
 
 v8::Persistent<FunctionTemplate> StereoBM::constructor;
@@ -17,11 +21,11 @@ StereoBM::Init(Handle<Object> target) {
     ctor->SetClassName(NanNew("StereoBM"));
 
     NODE_SET_PROTOTYPE_METHOD(ctor, "compute", Compute);
-
-    ctor->Set(NanNew<String>("BASIC_PRESET"), NanNew<Integer>((int)0));
-    ctor->Set(NanNew<String>("FISH_EYE_PRESET"), NanNew<Integer>((int)1));
-    ctor->Set(NanNew<String>("NARROW_PRESET"), NanNew<Integer>((int)2));
-
+#if CV_MAJOR_VERSION < 3
+    ctor->Set(NanNew<String>("BASIC_PRESET"), NanNew<Integer>((int)cv::StereoBM::BASIC_PRESET));
+    ctor->Set(NanNew<String>("FISH_EYE_PRESET"), NanNew<Integer>((int)cv::StereoBM::FISH_EYE_PRESET));
+    ctor->Set(NanNew<String>("NARROW_PRESET"), NanNew<Integer>((int)cv::StereoBM::NARROW_PRESET));
+#endif
     target->Set(NanNew("StereoBM"), ctor->GetFunction());
 }
 
@@ -229,7 +233,7 @@ NAN_METHOD(StereoSGBM::Compute)
     }
 
 };
-#if 0
+#if CV_VERSION_MAJOR < 3
 // Graph cut
 
 v8::Persistent<FunctionTemplate> StereoGC::constructor;

--- a/src/Stereo.h
+++ b/src/Stereo.h
@@ -2,23 +2,24 @@
 #define __NODE_STEREO_H
 
 #include "OpenCV.h"
+#include <opencv2/calib3d.hpp>
 
 class StereoBM: public node::ObjectWrap {
 public:
-    cv::StereoBM stereo;
+    cv::Ptr<cv::StereoBM> stereo;
 
     static Persistent<FunctionTemplate> constructor;
     static void Init(Handle<Object> target);
     static NAN_METHOD(New);
 
-    StereoBM(int preset = cv::StereoBM::BASIC_PRESET, int ndisparities = 0, int SADWindowSize=21);
+    StereoBM( int ndisparities = 0, int blockSize=21);
 
     JSFUNC(Compute);
 };
 
 class StereoSGBM: public node::ObjectWrap {
 public:
-    cv::StereoSGBM stereo;
+    cv::Ptr<cv::StereoSGBM> stereo;
 
     static Persistent<FunctionTemplate> constructor;
     static void Init(Handle<Object> target);
@@ -39,7 +40,7 @@ public:
 
     JSFUNC(Compute);
 };
-
+#if 0
 struct CvStereoGCState;
 
 class StereoGC: public node::ObjectWrap {
@@ -54,5 +55,5 @@ public:
 
     JSFUNC(Compute);
 };
-
+#endif
 #endif

--- a/src/Stereo.h
+++ b/src/Stereo.h
@@ -40,7 +40,9 @@ public:
 
     JSFUNC(Compute);
 };
-#if 0
+
+#if CV_VERSION_MAJOR < 3
+
 struct CvStereoGCState;
 
 class StereoGC: public node::ObjectWrap {

--- a/src/init.cc
+++ b/src/init.cc
@@ -31,8 +31,9 @@ init(Handle<Object> target) {
     ImgProc::Init(target);
     StereoBM::Init(target);
     StereoSGBM::Init(target);
-    //StereoGC::Init(target);
-
+#if CV_MAJOR_VERSION < 3
+    StereoGC::Init(target);
+#endif
 
    #if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4
       Features::Init(target);

--- a/src/init.cc
+++ b/src/init.cc
@@ -31,7 +31,7 @@ init(Handle<Object> target) {
     ImgProc::Init(target);
     StereoBM::Init(target);
     StereoSGBM::Init(target);
-    StereoGC::Init(target);
+    //StereoGC::Init(target);
 
 
    #if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4


### PR DESCRIPTION
I pulled in all required header files to make the module compile against OpenCV 3.0.0 on my Linux machine.
The stereo matching changed, I updated the data types to the new instantiation scheme, but this needs testing.
As a quick resolution against legacy headers, I disabled the StereoGC part - anyone savvy with this? 