### PR TITLE
Explicit Memory Management

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -101,7 +101,7 @@ Matrix::Init(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(ctor, "setWithMask", SetWithMask);
   NODE_SET_PROTOTYPE_METHOD(ctor, "meanWithMask", MeanWithMask);
   NODE_SET_PROTOTYPE_METHOD(ctor, "shift", Shift);
-  NODE_SET_PROTOTYPE_METHOD(ctor, "release", Dispose);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "release", Release);
 
   target->Set(NanNew("Matrix"), ctor->GetFunction());
 };
@@ -2257,9 +2257,11 @@ NAN_METHOD(Matrix::Shift){
 
 NAN_METHOD(Matrix::Release)
 {
-	SETUP_FUNCTION(Matrix)
+	NanScope();
 
-	mat.release();
+	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+
+	self->mat.release();
 
 	NanReturnUndefined();
 }

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -101,6 +101,7 @@ Matrix::Init(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(ctor, "setWithMask", SetWithMask);
   NODE_SET_PROTOTYPE_METHOD(ctor, "meanWithMask", MeanWithMask);
   NODE_SET_PROTOTYPE_METHOD(ctor, "shift", Shift);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "release", Dispose);
 
   target->Set(NanNew("Matrix"), ctor->GetFunction());
 };
@@ -2252,4 +2253,13 @@ NAN_METHOD(Matrix::Shift){
   self->mat = res;
 
   NanReturnUndefined();
+}
+
+NAN_METHOD(Matrix::Release)
+{
+	SETUP_FUNCTION(Matrix)
+
+	mat.release();
+
+	NanReturnUndefined();
 }

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -115,6 +115,8 @@ class Matrix: public node::ObjectWrap {
     JSFUNC(SetWithMask)
     JSFUNC(MeanWithMask)
     JSFUNC(Shift)
+
+    JSFUNC(Release)
 /*
     static Handle<Value> Val(const Arguments& args);
     static Handle<Value> RowRange(const Arguments& args);


### PR DESCRIPTION
As per #209 and my own experiments, it seems like nodejs is kind of terrible when it comes to managing the lifetime of these images for whatever reason (especially if you use promises). Luckily opencv provides us with a release function that we can use to force memory to be freed, so I exposed it to the Javascript side. Preliminary testing shows that this saves a huge amount of memory over a large number of operations, and I highly recommend that people use it for production code.

I'll give you some time to review this if you want to pull it in yourself, otherwise I'll do it myself next week. 