### PR TITLE
Only run equalizeHist() if an BGR matrix was provided

### DIFF
--- a/src/CascadeClassifierWrap.cc
+++ b/src/CascadeClassifierWrap.cc
@@ -61,10 +61,10 @@ class AsyncDetectMultiScale : public NanAsyncWorker {
 
       if(this->im->mat.channels() != 1) {
         cvtColor(this->im->mat, gray, CV_BGR2GRAY);
+        equalizeHist( gray, gray);
       } else {
         gray = this->im->mat;
       }
-      equalizeHist( gray, gray);
       this->cc->cc.detectMultiScale(gray, objects, this->scale, this->neighbors, 0 | CV_HAAR_SCALE_IMAGE, cv::Size(this->minw, this->minh));
       res = objects;
     }


### PR DESCRIPTION
This is a follow-up to 5026afa. For a grayscale matrix, it would be nice if the caller can decide whether running `equalizeHist` is appropriate.

Aside from that, a grayscale matrix running `equalizeHist` here modifies the source matrix (my bad!), which can cause concurrency problems. One workaround for this would be to duplicate the grayscale matrix within `AsyncDetectMultiScale` but that may be undesirable from a performance perspective when there are multiple cascades running concurrently in the system.