### PR TITLE
Fix code formatting for native code closes #295

### DIFF
--- a/js_code_style.xml
+++ b/js_code_style.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="11">
+<profile kind="CodeFormatterProfile" name=“opencv” version="11">
+<setting id="org.eclipse.wst.jsdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_after_annotation" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.format_header" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_colon_in_object_initializer" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_between_type_declarations" value="0"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.tabulation.size" value="2"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.continuation_indentation_for_objlit_initializer" value="1"/>
+<setting id="org.eclipse.wst.jsdt.core.compiler.compliance" value="1.5"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_before_closing_brace_in_objlit_initializer" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_after_comma_in_objlit_initializer" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.indentation.size" value="2"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_objlit_initializer" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.compiler.source" value="1.5"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.indent_parameter_description" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_before_imports" value="1"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.lineSplit" value="80"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.compiler.codegen.targetPlatform" value="1.5"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.keep_empty_objlit_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_colon_in_object_initializer" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.line_length" value="80"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_after_opening_brace_in_objlit_initializer" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+</profile>
+</profiles>

--- a/native_code_style.xml
+++ b/native_code_style.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="1">
+<profile kind="CodeFormatterProfile" name=“opencv” version="1">
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.lineSplit" value="80"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_member_access" value="0"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_base_types" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_constructor_initializer_list" value="51"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_exception_specification" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_base_types" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_body_declarations_compare_to_access_specifier" value="true"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_exception_specification" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_template_arguments" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.comment.min_distance_between_code_and_line_comment" value="2"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_declarator_list" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_bracket" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.tabulation.size" value="2"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_enumerator_list" value="48"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_declarator_list" value="16"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.cdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_closing_angle_bracket_in_template_arguments" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_colon_in_base_clause" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_declarator_list" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_between_empty_brackets" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_bracket" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.cdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_angle_bracket_in_template_arguments" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_expression_list" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_angle_bracket_in_template_parameters" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_expression_list" value="0"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_template_parameters" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_conditional_expression" value="34"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_access_specifier_extra_spaces" value="0"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_access_specifier_compare_to_type_header" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_body_declarations_compare_to_namespace_header" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_assignment" value="16"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_conditional_expression_chain" value="18"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_template_parameters" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_expression_list" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_exception_specification" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_identifier_in_function_declaration" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_base_clause_in_type_declaration" value="80"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_between_empty_parens_in_exception_specification" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_declaration_compare_to_template_header" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.cdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_template_arguments" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_angle_bracket_in_template_parameters" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_angle_bracket_in_template_parameters" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_colon_in_constructor_initializer_list" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.cdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_new_line_after_template_declaration" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_colon_in_base_clause" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.cdt.core.formatter.alignment_for_overloaded_left_shift_chain" value="16"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.indentation.size" value="2"/>
+<setting id="org.eclipse.cdt.core.formatter.brace_position_for_namespace_declaration" value="end_of_line"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_angle_bracket_in_template_arguments" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_namespace_declaration" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_bracket" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_closing_angle_bracket_in_template_parameters" value="insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_angle_bracket_in_template_arguments" value="do not insert"/>
+</profile>
+</profiles>

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -3,37 +3,35 @@
 #include <iostream>
 #include <nan.h>
 
-#if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4
+#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
 
 Persistent<FunctionTemplate> BackgroundSubtractorWrap::constructor;
 
-void
-BackgroundSubtractorWrap::Init(Handle<Object> target) {
-    NanScope();
+void BackgroundSubtractorWrap::Init(Handle<Object> target) {
+  NanScope();
 
-    // Constructor
-    Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(BackgroundSubtractorWrap::New);
-    NanAssignPersistent(constructor, ctor);
-    ctor->InstanceTemplate()->SetInternalFieldCount(1);
-    ctor->SetClassName(NanNew("BackgroundSubtractor"));
+  // Constructor
+  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(BackgroundSubtractorWrap::New);
+  NanAssignPersistent(constructor, ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(NanNew("BackgroundSubtractor"));
 
-    NODE_SET_METHOD(ctor, "createMOG", CreateMOG);
-    NODE_SET_PROTOTYPE_METHOD(ctor, "applyMOG", ApplyMOG);
+  NODE_SET_METHOD(ctor, "createMOG", CreateMOG);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "applyMOG", ApplyMOG);
 
-    target->Set(NanNew("BackgroundSubtractor"), ctor->GetFunction());
-
-};
+  target->Set(NanNew("BackgroundSubtractor"), ctor->GetFunction());
+}
 
 NAN_METHOD(BackgroundSubtractorWrap::New) {
   NanScope();
 
-  if (args.This()->InternalFieldCount() == 0)
+  if (args.This()->InternalFieldCount() == 0) {
     JSTHROW_TYPE("Cannot Instantiate without new")
+  }
 
-  //Create MOG by default
+  // Create MOG by default
   cv::Ptr<cv::BackgroundSubtractor> bg;
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
-
   pt->Wrap(args.This());
 
   NanReturnValue(args.This());
@@ -61,45 +59,39 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateMOG) {
 
   pt->Wrap(n);
   NanReturnValue( n );
-};
+}
 
-//Fetch foreground mask
+// Fetch foreground mask
 NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
-
-  SETUP_FUNCTION(BackgroundSubtractorWrap)
-
+  SETUP_FUNCTION(BackgroundSubtractorWrap);
   REQ_FUN_ARG(1, cb);
 
   Local<Value> argv[2];
-
-  if(args.Length() == 0){
+  if (args.Length() == 0) {
     argv[0] = NanNew("Input image missing");
     argv[1] = NanNull();
     cb->Call(NanGetCurrentContext()->Global(), 2, argv);
     NanReturnUndefined();
   }
 
-  try{
-
-    Local<Object> fgMask = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+  try {
+    Local<Object> fgMask =
+        NanNew(Matrix::constructor)->GetFunction()->NewInstance();
     Matrix *img = ObjectWrap::Unwrap<Matrix>(fgMask);
 
-
     cv::Mat mat;
-
-    if(Buffer::HasInstance(args[0])){
+    if (Buffer::HasInstance(args[0])) {
       uint8_t *buf = (uint8_t *) Buffer::Data(args[0]->ToObject());
       unsigned len = Buffer::Length(args[0]->ToObject());
       cv::Mat *mbuf = new cv::Mat(len, 1, CV_64FC1, buf);
       mat = cv::imdecode(*mbuf, -1);
       //mbuf->release();
-    }
-    else{
+    } else {
       Matrix *_img = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
       mat = (_img->mat).clone();
     }
 
-    if (mat.empty()){
+    if (mat.empty()) {
       return NanThrowTypeError("Error loading file");
     }
 
@@ -107,33 +99,29 @@ NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
     self->subtractor->operator()(mat, _fgMask);
 
     img->mat = _fgMask;
-
     mat.release();
 
     argv[0] = NanNull();
     argv[1] = fgMask;
 
     TryCatch try_catch;
-
     cb->Call(NanGetCurrentContext()->Global(), 2, argv);
 
     if (try_catch.HasCaught()) {
-        FatalException(try_catch);
-      }
-
-      NanReturnUndefined();
-  }
-  catch( cv::Exception& e ){
+      FatalException(try_catch);
+    }
+    NanReturnUndefined();
+  } catch (cv::Exception& e) {
     const char* err_msg = e.what();
     NanThrowError(err_msg);
     NanReturnUndefined();
   }
+}
 
-};
-
-BackgroundSubtractorWrap::BackgroundSubtractorWrap(cv::Ptr<cv::BackgroundSubtractor> _subtractor){
+BackgroundSubtractorWrap::BackgroundSubtractorWrap(
+    cv::Ptr<cv::BackgroundSubtractor> _subtractor) {
   subtractor = _subtractor;
-};
+}
 
 #endif
 

--- a/src/BackgroundSubtractor.h
+++ b/src/BackgroundSubtractor.h
@@ -1,21 +1,21 @@
 #include "OpenCV.h"
 
-#if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4
+#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
 
 #include <opencv2/video/background_segm.hpp>
 
 class BackgroundSubtractorWrap: public node::ObjectWrap {
-  public:
-    cv::Ptr<cv::BackgroundSubtractor> subtractor;
+public:
+  cv::Ptr<cv::BackgroundSubtractor> subtractor;
 
-    static Persistent<FunctionTemplate> constructor;
-    static void Init(Handle<Object> target);
-    static NAN_METHOD(New);
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(New);
 
-    BackgroundSubtractorWrap(cv::Ptr<cv::BackgroundSubtractor> bg);
+  BackgroundSubtractorWrap(cv::Ptr<cv::BackgroundSubtractor> bg);
 
-    static NAN_METHOD(CreateMOG);
-    static NAN_METHOD(ApplyMOG);
+  static NAN_METHOD(CreateMOG);
+  static NAN_METHOD(ApplyMOG);
 };
 
 #endif

--- a/src/Calib3D.cc
+++ b/src/Calib3D.cc
@@ -1,589 +1,560 @@
 #include "Calib3D.h"
 #include "Matrix.h"
 
-inline Local<Object> matrixFromMat(cv::Mat &input)
-{
-    Local<Object> matrixWrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-    Matrix *matrix = ObjectWrap::Unwrap<Matrix>(matrixWrap);
-    matrix->mat = input;
+inline Local<Object> matrixFromMat(cv::Mat &input) {
+  Local<Object> matrixWrap =
+      NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+  Matrix *matrix = ObjectWrap::Unwrap<Matrix>(matrixWrap);
+  matrix->mat = input;
 
-    return matrixWrap;
+  return matrixWrap;
 }
 
-inline cv::Mat matFromMatrix(Handle<Value> matrix)
-{
-    Matrix* m = ObjectWrap::Unwrap<Matrix>(matrix->ToObject());
-    return m->mat;
+inline cv::Mat matFromMatrix(Handle<Value> matrix) {
+  Matrix* m = ObjectWrap::Unwrap<Matrix>(matrix->ToObject());
+  return m->mat;
 }
 
-inline cv::Size sizeFromArray(Handle<Value> jsArray)
-{
-    cv::Size patternSize;
+inline cv::Size sizeFromArray(Handle<Value> jsArray) {
+  cv::Size patternSize;
 
-    if (jsArray->IsArray())
-    {
-        Local<Object> v8sz = jsArray->ToObject();
+  if (jsArray->IsArray()) {
+    Local<Object> v8sz = jsArray->ToObject();
 
-        patternSize = cv::Size(v8sz->Get(0)->IntegerValue(), v8sz->Get(1)->IntegerValue());
-    }
-    else
-    {
-        JSTHROW_TYPE("Size is not a valid array");
-    }
+    patternSize = cv::Size(v8sz->Get(0)->IntegerValue(),
+        v8sz->Get(1)->IntegerValue());
+  } else {
+    JSTHROW_TYPE("Size is not a valid array");
+  }
 
-    return patternSize;
+  return patternSize;
 }
 
-inline std::vector<cv::Point2f> points2fFromArray(Handle<Value> array)
-{
-    std::vector<cv::Point2f> points;
-    if(array->IsArray())
-    {
-        Local<Array> pointsArray =  Local<Array>::Cast(array->ToObject());
+inline std::vector<cv::Point2f> points2fFromArray(Handle<Value> array) {
+  std::vector<cv::Point2f> points;
+  if (array->IsArray()) {
+    Local<Array> pointsArray = Local<Array>::Cast(array->ToObject());
 
-        for(unsigned int i = 0; i < pointsArray->Length(); i++)
-        {
-            Local<Object> pt = pointsArray->Get(i)->ToObject();
-            points.push_back(cv::Point2f(pt->Get(NanNew<String>("x"))->ToNumber()->Value(),
-                                         pt->Get(NanNew<String>("y"))->ToNumber()->Value()));
-        }
+    for (unsigned int i = 0; i < pointsArray->Length(); i++) {
+      Local<Object> pt = pointsArray->Get(i)->ToObject();
+      points.push_back(
+          cv::Point2f(pt->Get(NanNew<String>("x"))->ToNumber()->Value(),
+              pt->Get(NanNew<String>("y"))->ToNumber()->Value()));
     }
-    else
-    {
-        JSTHROW_TYPE("Points not a valid array");
-    }
+  } else {
+    JSTHROW_TYPE("Points not a valid array");
+  }
 
-    return points;
+  return points;
 }
 
-inline std::vector<cv::Point3f> points3fFromArray(Handle<Value> array)
-{
-    std::vector<cv::Point3f> points;
-    if(array->IsArray()) {
-        Local<Array> pointsArray = Local<Array>::Cast(array->ToObject());
+inline std::vector<cv::Point3f> points3fFromArray(Handle<Value> array) {
+  std::vector<cv::Point3f> points;
+  if (array->IsArray()) {
+    Local<Array> pointsArray = Local<Array>::Cast(array->ToObject());
 
-        for(unsigned int i = 0; i < pointsArray->Length(); i++)
-        {
-            Local<Object> pt = pointsArray->Get(i)->ToObject();
-            points.push_back(cv::Point3f(pt->Get(NanNew<String>("x"))->ToNumber()->Value(),
-                                         pt->Get(NanNew<String>("y"))->ToNumber()->Value(),
-                                         pt->Get(NanNew<String>("z"))->ToNumber()->Value()));
-        }
+    for (unsigned int i = 0; i < pointsArray->Length(); i++) {
+      Local<Object> pt = pointsArray->Get(i)->ToObject();
+      points.push_back(
+          cv::Point3f(pt->Get(NanNew<String>("x"))->ToNumber()->Value(),
+              pt->Get(NanNew<String>("y"))->ToNumber()->Value(),
+              pt->Get(NanNew<String>("z"))->ToNumber()->Value()));
     }
-    else
-    {
-        JSTHROW_TYPE("Must pass array of object points for each frame")
-    }
+  } else {
+    JSTHROW_TYPE("Must pass array of object points for each frame")
+  }
 
-    return points;
+  return points;
 }
 
-inline std::vector<std::vector<cv::Point2f> > points2fFromArrayOfArrays(Handle<Value> array)
-{
-    std::vector<std::vector<cv::Point2f> > points;
-    if(array->IsArray())
-    {
-        Local<Array> pointsArray = Local<Array>::Cast(array->ToObject());
+inline std::vector<std::vector<cv::Point2f> > points2fFromArrayOfArrays(
+    Handle<Value> array) {
+  std::vector<std::vector<cv::Point2f> > points;
+  if (array->IsArray()) {
+    Local<Array> pointsArray = Local<Array>::Cast(array->ToObject());
 
-        for(unsigned int i = 0; i < pointsArray->Length(); i++)
-        {
-            points.push_back(points2fFromArray(pointsArray->Get(i)));
-        }
+    for (unsigned int i = 0; i < pointsArray->Length(); i++) {
+      points.push_back(points2fFromArray(pointsArray->Get(i)));
     }
-    else
-    {
-        JSTHROW_TYPE("Must pass array of object points for each frame")
-    }
+  } else {
+    JSTHROW_TYPE("Must pass array of object points for each frame")
+  }
 
-    return points;
+  return points;
 }
 
-inline std::vector<std::vector<cv::Point3f> > points3fFromArrayOfArrays(Handle<Value> array)
-{
-    std::vector<std::vector<cv::Point3f> > points;
-    if(array->IsArray())
-    {
-        Local<Array> pointsArray = Local<Array>::Cast(array->ToObject());
+inline std::vector<std::vector<cv::Point3f> > points3fFromArrayOfArrays(
+    Handle<Value> array) {
+  std::vector<std::vector<cv::Point3f> > points;
+  if (array->IsArray()) {
+    Local<Array> pointsArray = Local<Array>::Cast(array->ToObject());
 
-        for(unsigned int i = 0; i < pointsArray->Length(); i++)
-        {
-            points.push_back(points3fFromArray(pointsArray->Get(i)));
-        }
+    for (unsigned int i = 0; i < pointsArray->Length(); i++) {
+      points.push_back(points3fFromArray(pointsArray->Get(i)));
     }
-    else
-    {
-        JSTHROW_TYPE("Must pass array of object points for each frame")
-    }
+  } else {
+    JSTHROW_TYPE("Must pass array of object points for each frame")
+  }
 
-    return points;
+  return points;
 }
 
-void Calib3D::Init(Handle<Object> target)
-{
-    Persistent<Object> inner;
-    Local<Object> obj = NanNew<Object>();
-    NanAssignPersistent(inner, obj);
+void Calib3D::Init(Handle<Object> target) {
+  Persistent<Object> inner;
+  Local<Object> obj = NanNew<Object>();
+  NanAssignPersistent(inner, obj);
 
-    NODE_SET_METHOD(obj, "findChessboardCorners", FindChessboardCorners);
-    NODE_SET_METHOD(obj, "drawChessboardCorners", DrawChessboardCorners);
-    NODE_SET_METHOD(obj, "calibrateCamera", CalibrateCamera);
-    NODE_SET_METHOD(obj, "solvePnP", SolvePnP);
-    NODE_SET_METHOD(obj, "getOptimalNewCameraMatrix", GetOptimalNewCameraMatrix);
-    NODE_SET_METHOD(obj, "stereoCalibrate", StereoCalibrate);
-    NODE_SET_METHOD(obj, "stereoRectify", StereoRectify);
-    NODE_SET_METHOD(obj, "computeCorrespondEpilines", ComputeCorrespondEpilines);
-    NODE_SET_METHOD(obj, "reprojectImageTo3d", ReprojectImageTo3D);
+  NODE_SET_METHOD(obj, "findChessboardCorners", FindChessboardCorners);
+  NODE_SET_METHOD(obj, "drawChessboardCorners", DrawChessboardCorners);
+  NODE_SET_METHOD(obj, "calibrateCamera", CalibrateCamera);
+  NODE_SET_METHOD(obj, "solvePnP", SolvePnP);
+  NODE_SET_METHOD(obj, "getOptimalNewCameraMatrix", GetOptimalNewCameraMatrix);
+  NODE_SET_METHOD(obj, "stereoCalibrate", StereoCalibrate);
+  NODE_SET_METHOD(obj, "stereoRectify", StereoRectify);
+  NODE_SET_METHOD(obj, "computeCorrespondEpilines", ComputeCorrespondEpilines);
+  NODE_SET_METHOD(obj, "reprojectImageTo3d", ReprojectImageTo3D);
 
-    target->Set(NanNew("calib3d"), obj);
+  target->Set(NanNew("calib3d"), obj);
 }
 
 // cv::findChessboardCorners
-NAN_METHOD(Calib3D::FindChessboardCorners)
-{
-    NanEscapableScope();
+NAN_METHOD(Calib3D::FindChessboardCorners) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments from javascript
+  try {
+    // Get the arguments from javascript
 
-        // Arg 0 is the image
-        cv::Mat mat = matFromMatrix(args[0]);
+    // Arg 0 is the image
+    cv::Mat mat = matFromMatrix(args[0]);
 
-        // Arg 1 is the pattern size
-        cv::Size patternSize = sizeFromArray(args[1]);
+    // Arg 1 is the pattern size
+    cv::Size patternSize = sizeFromArray(args[1]);
 
-        // Arg 2 would normally be the flags, ignoring this for now and using the default flags
+    // Arg 2 would normally be the flags, ignoring this for now and using the
+    // default flags
 
-        // Find the corners
-        std::vector<cv::Point2f> corners;
-        bool found = cv::findChessboardCorners(mat, patternSize, corners);
+    // Find the corners
+    std::vector<cv::Point2f> corners;
+    bool found = cv::findChessboardCorners(mat, patternSize, corners);
 
-        // Make the return value
-        Local<Object> ret = NanNew<Object>();
-        ret->Set(NanNew<String>("found"), NanNew<Boolean>(found));
+    // Make the return value
+    Local<Object> ret = NanNew<Object>();
+    ret->Set(NanNew<String>("found"), NanNew<Boolean>(found));
 
-        Local<Array> cornersArray = NanNew<Array>(corners.size());
-        for(unsigned int i = 0; i < corners.size(); i++)
-        {
-            Local<Object> point_data = NanNew<Object>();
-            point_data->Set(NanNew<String>("x"), NanNew<Number>(corners[i].x));
-            point_data->Set(NanNew<String>("y"), NanNew<Number>(corners[i].y));
+    Local<Array> cornersArray = NanNew<Array>(corners.size());
+    for (unsigned int i = 0; i < corners.size(); i++) {
+      Local<Object> point_data = NanNew<Object>();
+      point_data->Set(NanNew<String>("x"), NanNew<Number>(corners[i].x));
+      point_data->Set(NanNew<String>("y"), NanNew<Number>(corners[i].y));
 
-            cornersArray->Set(NanNew<Number>(i), point_data);
-        }
-
-        ret->Set(NanNew<String>("corners"), cornersArray);
-
-        NanReturnValue(ret);
-
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
+      cornersArray->Set(NanNew<Number>(i), point_data);
     }
 
-};
+    ret->Set(NanNew<String>("corners"), cornersArray);
+
+    NanReturnValue(ret);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
+}
 
 // cv::drawChessboardCorners
-NAN_METHOD(Calib3D::DrawChessboardCorners)
-{
-    NanEscapableScope();
+NAN_METHOD(Calib3D::DrawChessboardCorners) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg 0 is the image
-        cv::Mat mat = matFromMatrix(args[0]);
+    // Arg 0 is the image
+    cv::Mat mat = matFromMatrix(args[0]);
 
-        // Arg 1 is the pattern size
-        cv::Size patternSize = sizeFromArray(args[1]);
+    // Arg 1 is the pattern size
+    cv::Size patternSize = sizeFromArray(args[1]);
 
-        // Arg 2 is the corners array
-        std::vector<cv::Point2f> corners = points2fFromArray(args[2]);
+    // Arg 2 is the corners array
+    std::vector<cv::Point2f> corners = points2fFromArray(args[2]);
 
-        // Arg 3, pattern found boolean
-        bool patternWasFound = args[3]->ToBoolean()->Value();
+    // Arg 3, pattern found boolean
+    bool patternWasFound = args[3]->ToBoolean()->Value();
 
-        // Draw the corners
-        cv::drawChessboardCorners(mat, patternSize, corners, patternWasFound);
+    // Draw the corners
+    cv::drawChessboardCorners(mat, patternSize, corners, patternWasFound);
 
-        // Return the passed image, now with corners drawn on it
-        NanReturnValue(args[0]);
+    // Return the passed image, now with corners drawn on it
+    NanReturnValue(args[0]);
 
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }
 
 // cv::calibrateCamera
-NAN_METHOD(Calib3D::CalibrateCamera)
-{
-    NanEscapableScope();
+NAN_METHOD(Calib3D::CalibrateCamera) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg 0, the array of object points, an array of arrays
-        std::vector<std::vector<cv::Point3f> > objectPoints = points3fFromArrayOfArrays(args[0]);
+    // Arg 0, the array of object points, an array of arrays
+    std::vector<std::vector<cv::Point3f> > objectPoints =
+        points3fFromArrayOfArrays(args[0]);
 
-        // Arg 1, the image points, another array of arrays
-        std::vector<std::vector<cv::Point2f> > imagePoints = points2fFromArrayOfArrays(args[1]);
+    // Arg 1, the image points, another array of arrays
+    std::vector<std::vector<cv::Point2f> > imagePoints =
+        points2fFromArrayOfArrays(args[1]);
 
-        // Arg 2, the image size
-        cv::Size imageSize = sizeFromArray(args[2]);
+    // Arg 2, the image size
+    cv::Size imageSize = sizeFromArray(args[2]);
 
-        // Arg 3, 4, input guesses for the camrea matrix and distortion coefficients, skipping for now
-        cv::Mat K, dist;
+    // Arg 3, 4, input guesses for the camrea matrix and distortion coefficients,
+    // skipping for now
+    cv::Mat K, dist;
 
-        // Arg 5, 6 flags and termination criteria, skipping for now
+    // Arg 5, 6 flags and termination criteria, skipping for now
 
-        // Calibrate the camera
-        std::vector<cv::Mat> rvecs, tvecs;
+    // Calibrate the camera
+    std::vector<cv::Mat> rvecs, tvecs;
 
-        double error = cv::calibrateCamera(objectPoints, imagePoints, imageSize, K, dist, rvecs, tvecs);
+    double error = cv::calibrateCamera(objectPoints, imagePoints, imageSize, K,
+        dist, rvecs, tvecs);
 
-        // make the return values
-        Local<Object> ret = NanNew<Object>();
+    // make the return values
+    Local<Object> ret = NanNew<Object>();
 
-        // Reprojection error
-        ret->Set(NanNew<String>("reprojectionError"), NanNew<Number>(error));
+    // Reprojection error
+    ret->Set(NanNew<String>("reprojectionError"), NanNew<Number>(error));
 
-        // K
-        Local<Object> KMatrixWrap = matrixFromMat(K);
-        ret->Set(NanNew<String>("K"), KMatrixWrap);
+    // K
+    Local<Object> KMatrixWrap = matrixFromMat(K);
+    ret->Set(NanNew<String>("K"), KMatrixWrap);
 
-        // dist
-        Local<Object> distMatrixWrap = matrixFromMat(dist);
-        ret->Set(NanNew<String>("distortion"), distMatrixWrap);
+    // dist
+    Local<Object> distMatrixWrap = matrixFromMat(dist);
+    ret->Set(NanNew<String>("distortion"), distMatrixWrap);
 
-        // Per frame R and t, skiping for now
+    // Per frame R and t, skiping for now
 
-        // Return
-        NanReturnValue(ret);
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
+    // Return
+    NanReturnValue(ret);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }
 
 // cv::solvePnP
-NAN_METHOD(Calib3D::SolvePnP)
-{
-    NanEscapableScope();
+NAN_METHOD(Calib3D::SolvePnP) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg 0, the array of object points
-        std::vector<cv::Point3f> objectPoints = points3fFromArray(args[0]);
+    // Arg 0, the array of object points
+    std::vector<cv::Point3f> objectPoints = points3fFromArray(args[0]);
 
-        // Arg 1, the image points
-        std::vector<cv::Point2f> imagePoints = points2fFromArray(args[1]);
+    // Arg 1, the image points
+    std::vector<cv::Point2f> imagePoints = points2fFromArray(args[1]);
 
-        // Arg 2, the camera matrix
-        cv::Mat K = matFromMatrix(args[2]);
+    // Arg 2, the camera matrix
+    cv::Mat K = matFromMatrix(args[2]);
 
-        // Arg 3, the distortion coefficients
-        cv::Mat dist = matFromMatrix(args[3]);
+    // Arg 3, the distortion coefficients
+    cv::Mat dist = matFromMatrix(args[3]);
 
-        // Arg 4, use extrinsic guess, skipped for now
+    // Arg 4, use extrinsic guess, skipped for now
 
-        // Arg 5, flags, skip for now
+    // Arg 5, flags, skip for now
 
-        // solve for r and t
-        cv::Mat rvec, tvec;
+    // solve for r and t
+    cv::Mat rvec, tvec;
 
-        cv::solvePnP(objectPoints, imagePoints, K, dist, rvec, tvec);
+    cv::solvePnP(objectPoints, imagePoints, K, dist, rvec, tvec);
 
-        // make the return values
-        Local<Object> ret = NanNew<Object>();
+    // make the return values
+    Local<Object> ret = NanNew<Object>();
 
-        // rvec
-        Local<Object> rMatrixWrap = matrixFromMat(rvec);
-        ret->Set(NanNew<String>("rvec"), rMatrixWrap);
+    // rvec
+    Local<Object> rMatrixWrap = matrixFromMat(rvec);
+    ret->Set(NanNew<String>("rvec"), rMatrixWrap);
 
-        // tvec
-        Local<Object> tMatrixWrap = matrixFromMat(tvec);
-        ret->Set(NanNew<String>("tvec"), tMatrixWrap);
+    // tvec
+    Local<Object> tMatrixWrap = matrixFromMat(tvec);
+    ret->Set(NanNew<String>("tvec"), tMatrixWrap);
 
-        // Return
-        NanReturnValue(ret);
+    // Return
+    NanReturnValue(ret);
 
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }
 
 // cv::getOptimalNewCameraMAtrix
-NAN_METHOD(Calib3D::GetOptimalNewCameraMatrix)
-{
-    NanEscapableScope();
+NAN_METHOD(Calib3D::GetOptimalNewCameraMatrix) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg 0 is the original camera matrix
-        cv::Mat Kin = matFromMatrix(args[0]);
+    // Arg 0 is the original camera matrix
+    cv::Mat Kin = matFromMatrix(args[0]);
 
-        // Arg 1 is the distortion coefficients
-        cv::Mat dist = matFromMatrix(args[1]);
+    // Arg 1 is the distortion coefficients
+    cv::Mat dist = matFromMatrix(args[1]);
 
-        // Arg 2, the image size
-        cv::Size imageSize = sizeFromArray(args[2]);
+    // Arg 2, the image size
+    cv::Size imageSize = sizeFromArray(args[2]);
 
-        // Arg 3 is the alpha free scaling parameter
-        double alpha = args[3]->ToNumber()->Value();
+    // Arg 3 is the alpha free scaling parameter
+    double alpha = args[3]->ToNumber()->Value();
 
-        // Arg 4, the new image size
-        cv::Size newImageSize = sizeFromArray(args[4]);
+    // Arg 4, the new image size
+    cv::Size newImageSize = sizeFromArray(args[4]);
 
-        // Arg 5, valid ROI, skip for now
-        // Arg 6, center principal point, skip for now
+    // Arg 5, valid ROI, skip for now
+    // Arg 6, center principal point, skip for now
 
-        // Get the optimal new camera matrix
-        cv::Mat Kout = cv::getOptimalNewCameraMatrix(Kin, dist, imageSize, alpha, newImageSize);
+    // Get the optimal new camera matrix
+    cv::Mat Kout = cv::getOptimalNewCameraMatrix(Kin, dist, imageSize, alpha,
+        newImageSize);
 
-        // Wrap the output K
-        Local<Object> KMatrixWrap = matrixFromMat(Kout);
+    // Wrap the output K
+    Local<Object> KMatrixWrap = matrixFromMat(Kout);
 
-        // Return the new K matrix
-        NanReturnValue(KMatrixWrap);
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
+    // Return the new K matrix
+    NanReturnValue(KMatrixWrap);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }
 
 // cv::stereoCalibrate
-NAN_METHOD(Calib3D::StereoCalibrate)
-{
-    NanEscapableScope();
+NAN_METHOD(Calib3D::StereoCalibrate) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg 0, the array of object points, an array of arrays
-        std::vector<std::vector<cv::Point3f> > objectPoints = points3fFromArrayOfArrays(args[0]);
+    // Arg 0, the array of object points, an array of arrays
+    std::vector<std::vector<cv::Point3f> > objectPoints =
+        points3fFromArrayOfArrays(args[0]);
 
-        // Arg 1, the image points1, another array of arrays
-        std::vector<std::vector<cv::Point2f> > imagePoints1 = points2fFromArrayOfArrays(args[1]);
+    // Arg 1, the image points1, another array of arrays
+    std::vector<std::vector<cv::Point2f> > imagePoints1 =
+        points2fFromArrayOfArrays(args[1]);
 
-        // Arg 2, the image points2, another array of arrays =(
-        std::vector<std::vector<cv::Point2f> > imagePoints2 = points2fFromArrayOfArrays(args[2]);
+    // Arg 2, the image points2, another array of arrays =(
+    std::vector<std::vector<cv::Point2f> > imagePoints2 =
+        points2fFromArrayOfArrays(args[2]);
 
-        // Arg 3 is the image size (follows the PYTHON api not the C++ api since all following arguments are optional or outputs)
-        cv::Size imageSize = sizeFromArray(args[3]);
+    // Arg 3 is the image size (follows the PYTHON api not the C++ api since all
+    // following arguments are optional or outputs)
+    cv::Size imageSize = sizeFromArray(args[3]);
 
-        // Arg 4,5,6,7 is the camera matrix and distortion coefficients (optional but must pass all 4 or none)
-        cv::Mat k1, d1, k2, d2;
-        if(args.Length() >= 8)
-        {
-            k1 = matFromMatrix(args[4]);
-            d1 =  matFromMatrix(args[5]);
+    // Arg 4,5,6,7 is the camera matrix and distortion coefficients
+    // (optional but must pass all 4 or none)
+    cv::Mat k1, d1, k2, d2;
+    if (args.Length() >= 8) {
+      k1 = matFromMatrix(args[4]);
+      d1 = matFromMatrix(args[5]);
 
-            k2 =  matFromMatrix(args[6]);
-            d2 =  matFromMatrix(args[7]);
-        }
-
-        // Last argument is flags, skipping for now
-
-        // Output mats
-        cv::Mat R, t, E, F;
-
-        // Do the stereo calibration
-        cv::stereoCalibrate(objectPoints, imagePoints1, imagePoints2, k1, d1, k2, d2, imageSize, R, t, E, F);
-
-        // make the return value
-        Local<Object> ret = NanNew<Object>();
-
-        // Make the output arguments
-
-        // k1
-        Local<Object> K1MatrixWrap = matrixFromMat(k1);
-
-        // d1
-        Local<Object> d1MatrixWrap = matrixFromMat(d1);
-
-        // k2
-        Local<Object> K2MatrixWrap = matrixFromMat(k2);
-
-        // d2
-        Local<Object> d2MatrixWrap = matrixFromMat(d2);
-
-        // R
-        Local<Object> RMatrixWrap = matrixFromMat(R);
-
-        // t
-        Local<Object> tMatrixWrap = matrixFromMat(t);
-
-        // E
-        Local<Object> EMatrixWrap = matrixFromMat(E);
-
-        // F
-        Local<Object> FMatrixWrap = matrixFromMat(F);
-
-        // Add to return object
-        ret->Set(NanNew<String>("K1"), K1MatrixWrap);
-        ret->Set(NanNew<String>("distortion1"), d1MatrixWrap);
-        ret->Set(NanNew<String>("K2"), K2MatrixWrap);
-        ret->Set(NanNew<String>("distortion2"), d2MatrixWrap);
-        ret->Set(NanNew<String>("R"), RMatrixWrap);
-        ret->Set(NanNew<String>("t"), tMatrixWrap);
-        ret->Set(NanNew<String>("E"), EMatrixWrap);
-        ret->Set(NanNew<String>("F"), FMatrixWrap);
-
-        // Return
-        NanReturnValue(ret);
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
+      k2 = matFromMatrix(args[6]);
+      d2 = matFromMatrix(args[7]);
     }
+
+    // Last argument is flags, skipping for now
+
+    // Output mats
+    cv::Mat R, t, E, F;
+
+    // Do the stereo calibration
+    cv::stereoCalibrate(objectPoints, imagePoints1, imagePoints2, k1, d1, k2,
+        d2, imageSize, R, t, E, F);
+
+    // make the return value
+    Local<Object> ret = NanNew<Object>();
+
+    // Make the output arguments
+
+    // k1
+    Local<Object> K1MatrixWrap = matrixFromMat(k1);
+
+    // d1
+    Local<Object> d1MatrixWrap = matrixFromMat(d1);
+
+    // k2
+    Local<Object> K2MatrixWrap = matrixFromMat(k2);
+
+    // d2
+    Local<Object> d2MatrixWrap = matrixFromMat(d2);
+
+    // R
+    Local<Object> RMatrixWrap = matrixFromMat(R);
+
+    // t
+    Local<Object> tMatrixWrap = matrixFromMat(t);
+
+    // E
+    Local<Object> EMatrixWrap = matrixFromMat(E);
+
+    // F
+    Local<Object> FMatrixWrap = matrixFromMat(F);
+
+    // Add to return object
+    ret->Set(NanNew<String>("K1"), K1MatrixWrap);
+    ret->Set(NanNew<String>("distortion1"), d1MatrixWrap);
+    ret->Set(NanNew<String>("K2"), K2MatrixWrap);
+    ret->Set(NanNew<String>("distortion2"), d2MatrixWrap);
+    ret->Set(NanNew<String>("R"), RMatrixWrap);
+    ret->Set(NanNew<String>("t"), tMatrixWrap);
+    ret->Set(NanNew<String>("E"), EMatrixWrap);
+    ret->Set(NanNew<String>("F"), FMatrixWrap);
+
+    // Return
+    NanReturnValue(ret);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }
 
 // cv::stereoRectify
-NAN_METHOD(Calib3D::StereoRectify)
-{
-    NanEscapableScope();
+NAN_METHOD(Calib3D::StereoRectify) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg0, the first camera matrix
-        cv::Mat K1 = matFromMatrix(args[0]);
+    // Arg0, the first camera matrix
+    cv::Mat K1 = matFromMatrix(args[0]);
 
-        // Arg1, the first distortion coefficients
-        cv::Mat d1 = matFromMatrix(args[1]);
+    // Arg1, the first distortion coefficients
+    cv::Mat d1 = matFromMatrix(args[1]);
 
-        // Arg2, the second camera matrix
-        cv::Mat K2 = matFromMatrix(args[2]);
+    // Arg2, the second camera matrix
+    cv::Mat K2 = matFromMatrix(args[2]);
 
-        // Arg3, the second distortion coefficients
-        cv::Mat d2 = matFromMatrix(args[3]);
+    // Arg3, the second distortion coefficients
+    cv::Mat d2 = matFromMatrix(args[3]);
 
-        // Arg4, the image size
-        cv::Size imageSize = sizeFromArray(args[4]);
+    // Arg4, the image size
+    cv::Size imageSize = sizeFromArray(args[4]);
 
-        // arg5, the intercamera rotation matrix
-        cv::Mat R = matFromMatrix(args[5]);
+    // arg5, the intercamera rotation matrix
+    cv::Mat R = matFromMatrix(args[5]);
 
-        // Arg6, the intercamera translation vector
-        cv::Mat t = matFromMatrix(args[6]);
+    // Arg6, the intercamera translation vector
+    cv::Mat t = matFromMatrix(args[6]);
 
-        // Arg8, flags, skipping for now
+    // Arg8, flags, skipping for now
 
-        // Arg9, freescaling paremeter, skipping for now
+    // Arg9, freescaling paremeter, skipping for now
 
-        // Arg10, new image size, skipping for now to fix at original image size
+    // Arg10, new image size, skipping for now to fix at original image size
 
-        // Make output matrics
-        cv::Mat R1, R2, P1, P2, Q;
+    // Make output matrics
+    cv::Mat R1, R2, P1, P2, Q;
 
-        // Do the stereo rectification
-        cv::stereoRectify(K1, d1, K2, d2, imageSize, R, t, R1, R2, P1, P2, Q);
+    // Do the stereo rectification
+    cv::stereoRectify(K1, d1, K2, d2, imageSize, R, t, R1, R2, P1, P2, Q);
 
-        // Make the return object
-        Local<Object> ret = NanNew<Object>();
+    // Make the return object
+    Local<Object> ret = NanNew<Object>();
 
-        ret->Set(NanNew<String>("R1"), matrixFromMat(R1));
-        ret->Set(NanNew<String>("R2"), matrixFromMat(R2));
-        ret->Set(NanNew<String>("P1"), matrixFromMat(P1));
-        ret->Set(NanNew<String>("P2"), matrixFromMat(P2));
-        ret->Set(NanNew<String>("Q"), matrixFromMat(Q));
+    ret->Set(NanNew<String>("R1"), matrixFromMat(R1));
+    ret->Set(NanNew<String>("R2"), matrixFromMat(R2));
+    ret->Set(NanNew<String>("P1"), matrixFromMat(P1));
+    ret->Set(NanNew<String>("P2"), matrixFromMat(P2));
+    ret->Set(NanNew<String>("Q"), matrixFromMat(Q));
 
-        // Return the recification parameters
-        NanReturnValue(ret);
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
+    // Return the rectification parameters
+    NanReturnValue(ret);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }
 
 // cv::computeCorrespondEpilines
-NAN_METHOD(Calib3D::ComputeCorrespondEpilines)
-{
-    NanEscapableScope();
+NAN_METHOD(Calib3D::ComputeCorrespondEpilines) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg0, the image points
-        std::vector<cv::Point2f> points = points2fFromArray(args[0]);
+    // Arg0, the image points
+    std::vector<cv::Point2f> points = points2fFromArray(args[0]);
 
-        // Arg1, the image index (1 or 2)
-        int whichImage = int(args[1]->ToNumber()->Value());
+    // Arg1, the image index (1 or 2)
+    int whichImage = int(args[1]->ToNumber()->Value());
 
-        // Arg2, the fundamental matrix
-        cv::Mat F = matFromMatrix(args[2]);
+    // Arg2, the fundamental matrix
+    cv::Mat F = matFromMatrix(args[2]);
 
-        // compute the lines
-        std::vector<cv::Vec3f> lines;
-        cv::computeCorrespondEpilines(points, whichImage, F, lines);
+    // compute the lines
+    std::vector<cv::Vec3f> lines;
+    cv::computeCorrespondEpilines(points, whichImage, F, lines);
 
-        // Convert the lines to an array of objects (ax + by + c = 0)
-        Local<Array> linesArray = NanNew<Array>(lines.size());
-        for(unsigned int i = 0; i < lines.size(); i++)
-        {
-            Local<Object> line_data = NanNew<Object>();
-            line_data->Set(NanNew<String>("a"), NanNew<Number>(lines[i][0]));
-            line_data->Set(NanNew<String>("b"), NanNew<Number>(lines[i][1]));
-            line_data->Set(NanNew<String>("c"), NanNew<Number>(lines[i][2]));
+    // Convert the lines to an array of objects (ax + by + c = 0)
+    Local<Array> linesArray = NanNew<Array>(lines.size());
+    for(unsigned int i = 0; i < lines.size(); i++)
+    {
+      Local<Object> line_data = NanNew<Object>();
+      line_data->Set(NanNew<String>("a"), NanNew<Number>(lines[i][0]));
+      line_data->Set(NanNew<String>("b"), NanNew<Number>(lines[i][1]));
+      line_data->Set(NanNew<String>("c"), NanNew<Number>(lines[i][2]));
 
-            linesArray->Set(NanNew<Number>(i), line_data);
-        }
-
-        // Return the lines
-        NanReturnValue(linesArray);
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
+      linesArray->Set(NanNew<Number>(i), line_data);
     }
+
+    // Return the lines
+    NanReturnValue(linesArray);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }
 
 // cv::reprojectImageTo3D
-NAN_METHOD(Calib3D::ReprojectImageTo3D)
-{
-    NanEscapableScope();
+NAN_METHOD(Calib3D::ReprojectImageTo3D) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg0, the disparity image
-        cv::Mat disparity = matFromMatrix(args[0]);
+    // Arg0, the disparity image
+    cv::Mat disparity = matFromMatrix(args[0]);
 
-        // Arg1, the depth-to-disparity transformation Q
-        cv::Mat Q = matFromMatrix(args[1]);
+    // Arg1, the depth-to-disparity transformation Q
+    cv::Mat Q = matFromMatrix(args[1]);
 
-        // Arg 2, handle missing values, skipped for now
+    // Arg 2, handle missing values, skipped for now
 
-        // Arg3, output bit depth, skipped for now
+    // Arg3, output bit depth, skipped for now
 
-        // Compute the depth image
-        cv::Mat depthImage;
-        cv::reprojectImageTo3D(disparity, depthImage, Q);
+    // Compute the depth image
+    cv::Mat depthImage;
+    cv::reprojectImageTo3D(disparity, depthImage, Q);
 
-        // Wrap the depth image
-        Local<Object> depthImageMatrix = matrixFromMat(depthImage);
+    // Wrap the depth image
+    Local<Object> depthImageMatrix = matrixFromMat(depthImage);
 
-        NanReturnValue(depthImageMatrix);
-
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
+    NanReturnValue(depthImageMatrix);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }

--- a/src/Calib3D.h
+++ b/src/Calib3D.h
@@ -3,29 +3,21 @@
 
 #include "OpenCV.h"
 
-// Implementation of calib3d.hpp functions
-
+/**
+ * Implementation of calib3d.hpp functions
+ */
 class Calib3D: public node::ObjectWrap {
 public:
-    static void Init(Handle<Object> target);
-
-    static NAN_METHOD(FindChessboardCorners);
-
-    static NAN_METHOD(DrawChessboardCorners);
-
-    static NAN_METHOD(CalibrateCamera);
-
-    static NAN_METHOD(SolvePnP);
-
-    static NAN_METHOD(GetOptimalNewCameraMatrix);
-
-    static NAN_METHOD(StereoCalibrate);
-
-    static NAN_METHOD(StereoRectify);
-
-    static NAN_METHOD(ComputeCorrespondEpilines);
-
-    static NAN_METHOD(ReprojectImageTo3D);
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(FindChessboardCorners);
+  static NAN_METHOD(DrawChessboardCorners);
+  static NAN_METHOD(CalibrateCamera);
+  static NAN_METHOD(SolvePnP);
+  static NAN_METHOD(GetOptimalNewCameraMatrix);
+  static NAN_METHOD(StereoCalibrate);
+  static NAN_METHOD(StereoRectify);
+  static NAN_METHOD(ComputeCorrespondEpilines);
+  static NAN_METHOD(ReprojectImageTo3D);
 };
 
 #endif

--- a/src/CamShift.cc
+++ b/src/CamShift.cc
@@ -10,30 +10,27 @@
 
 Persistent<FunctionTemplate> TrackedObject::constructor;
 
-void
-TrackedObject::Init(Handle<Object> target) {
-    NanScope();
+void TrackedObject::Init(Handle<Object> target) {
+  NanScope();
 
-    // Constructor
-    Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(TrackedObject::New);
-    NanAssignPersistent(constructor, ctor);
-    ctor->InstanceTemplate()->SetInternalFieldCount(1);
-    ctor->SetClassName(NanNew("TrackedObject"));
-    
+  // Constructor
+  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(TrackedObject::New);
+  NanAssignPersistent(constructor, ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(NanNew("TrackedObject"));
 
-    // Prototype
-    //Local<ObjectTemplate> proto = constructor->PrototypeTemplate();
+  // Prototype
+  // Local<ObjectTemplate> proto = constructor->PrototypeTemplate();
 
-	  NODE_SET_PROTOTYPE_METHOD(ctor, "track", Track);
-	  
-	  target->Set(NanNew("TrackedObject"), ctor->GetFunction());
-};    
+  NODE_SET_PROTOTYPE_METHOD(ctor, "track", Track);
 
+  target->Set(NanNew("TrackedObject"), ctor->GetFunction());
+}
 
 NAN_METHOD(TrackedObject::New) {
   NanScope();
 
-  if (args.This()->InternalFieldCount() == 0){
+  if (args.This()->InternalFieldCount() == 0) {
     JSTHROW_TYPE("Cannot Instantiate without new")
   }
 
@@ -41,135 +38,124 @@ NAN_METHOD(TrackedObject::New) {
   cv::Rect r;
   int channel = CHANNEL_HUE;
 
-  if (args[1]->IsArray()){
-    Local<Object> v8rec = args[1]->ToObject(); 
+  if (args[1]->IsArray()) {
+    Local<Object> v8rec = args[1]->ToObject();
     r = cv::Rect(
         v8rec->Get(0)->IntegerValue(),
         v8rec->Get(1)->IntegerValue(),
-        v8rec->Get(2)->IntegerValue() - v8rec->Get(0)->IntegerValue(), 
+        v8rec->Get(2)->IntegerValue() - v8rec->Get(0)->IntegerValue(),
         v8rec->Get(3)->IntegerValue() - v8rec->Get(1)->IntegerValue());
   } else {
-        JSTHROW_TYPE("Must pass rectangle to track")
+    JSTHROW_TYPE("Must pass rectangle to track")
   }
-  
-  if (args[2]->IsObject()){
+
+  if (args[2]->IsObject()) {
     Local<Object> opts = args[2]->ToObject();
 
-    if (opts->Get(NanNew("channel"))->IsString()){
+    if (opts->Get(NanNew("channel"))->IsString()) {
       v8::String::Utf8Value c(opts->Get(NanNew("channel"))->ToString());
       std::string cc = std::string(*c);
 
-      if (cc == "hue" || cc == "h"){
-          channel = CHANNEL_HUE;
+      if (cc == "hue" || cc == "h") {
+        channel = CHANNEL_HUE;
       }
 
-      if (cc == "saturation" || cc == "s"){
-          channel = CHANNEL_SATURATION;
+      if (cc == "saturation" || cc == "s") {
+        channel = CHANNEL_SATURATION;
       }
-          
-      if (cc == "value" || cc == "v"){
-          channel = CHANNEL_VALUE;
+
+      if (cc == "value" || cc == "v") {
+        channel = CHANNEL_VALUE;
       }
     }
   }
 
-  TrackedObject *to = new TrackedObject(m->mat, r, channel);  
-  
-  
+  TrackedObject *to = new TrackedObject(m->mat, r, channel);
+
   to->Wrap(args.This());
   NanReturnValue(args.This());
 }
 
-
-void update_chann_image(TrackedObject* t, cv::Mat image){
+void update_chann_image(TrackedObject* t, cv::Mat image) {
   // Store HSV Hue Image
-  cv::cvtColor(image, t->hsv, CV_BGR2HSV); // convert to HSV space
-  //mask out-of-range values
-  int vmin = 65, vmax = 256, smin = 55;
-  cv::inRange(t->hsv,                               //source
-        cv::Scalar(0, smin, MIN(vmin, vmax), 0),  //lower bound
-        cv::Scalar(180, 256, MAX(vmin, vmax) ,0), //upper bound
-        t->mask);                                    //destination 
+  cv::cvtColor(image, t->hsv, CV_BGR2HSV);  // convert to HSV space
 
-  //extract the hue channel, split: src, dest channels
+  // Mask out-of-range values
+  int vmin = 65, vmax = 256, smin = 55;
+  cv::inRange(t->hsv,  //source
+      cv::Scalar(0, smin, MIN(vmin, vmax), 0),  //lower bound
+      cv::Scalar(180, 256, MAX(vmin, vmax), 0),  //upper bound
+      t->mask);  //destination
+
+  // Extract the hue channel, split: src, dest channels
   std::vector<cv::Mat> hsvplanes;
   cv::split(t->hsv, hsvplanes);
   t->hue = hsvplanes[t->channel];
-  
-
 }
 
-TrackedObject::TrackedObject(cv::Mat image, cv::Rect rect, int chan){
+TrackedObject::TrackedObject(cv::Mat image, cv::Rect rect, int chan) {
   channel = chan;
   update_chann_image(this, image);
   prev_rect = rect;
-  
+
   // Calculate Histogram
   int hbins = 30, sbins = 32;
-  int histSizes[] = {hbins, sbins};
-  //float hranges[] = { 0, 180 };
+  int histSizes[] = { hbins, sbins };
+  // float hranges[] = { 0, 180 };
   // saturation varies from 0 (black-gray-white) to
   // 255 (pure spectrum color)
   float sranges[] = { 0, 256 };
   const float* ranges[] = { sranges };
-  
+
   cv::Mat hue_roi = hue(rect);
   cv::Mat mask_roi = mask(rect);
 
-  cv::calcHist(&hue_roi, 1, 0, mask_roi, hist, 1, histSizes, ranges, true, false);
-  
+  cv::calcHist(&hue_roi, 1, 0, mask_roi, hist, 1, histSizes, ranges, true,
+      false);
 }
 
+NAN_METHOD(TrackedObject::Track) {
+  SETUP_FUNCTION(TrackedObject)
 
-
-NAN_METHOD(TrackedObject::Track){
-	SETUP_FUNCTION(TrackedObject)
- 
-  if (args.Length() != 1){
+  if (args.Length() != 1) {
     NanThrowTypeError("track takes an image param");
     NanReturnUndefined();
   }
 
-
   Matrix *im = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
   cv::RotatedRect r;
-  
-  if (self->prev_rect.x <0 ||
-      self->prev_rect.y <0 ||
-      self->prev_rect.width <= 1 ||
-      self->prev_rect.height <= 1){
+
+  if ((self->prev_rect.x < 0) || (self->prev_rect.y < 0)
+      || (self->prev_rect.width <= 1) || (self->prev_rect.height <= 1)) {
     return NanThrowTypeError("OPENCV ERROR: prev rectangle is illogical");
   }
 
   update_chann_image(self, im->mat);
 
-  cv::Rect backup_prev_rect = cv::Rect(
-      self->prev_rect.x,
-      self->prev_rect.y,
-      self->prev_rect.width,
-      self->prev_rect.height);
-  
+  cv::Rect backup_prev_rect = cv::Rect(self->prev_rect.x, self->prev_rect.y,
+      self->prev_rect.width, self->prev_rect.height);
+
   float sranges[] = { 0, 256 };
   const float* ranges[] = { sranges };
   int channel = 0;
-  cv::calcBackProject(&self->hue, 1, &channel,  self->hist, self->prob, ranges);
- 
-  r = cv::CamShift(self->prob, self->prev_rect,
-        cv::TermCriteria(CV_TERMCRIT_EPS | CV_TERMCRIT_ITER, 10, 1));
+  cv::calcBackProject(&self->hue, 1, &channel, self->hist, self->prob, ranges);
 
-  cv::Rect bounds = r.boundingRect(); 
-  if (bounds.x >=0 && bounds.y >=0 && bounds.width > 1 && bounds.height > 1){
+  r = cv::CamShift(self->prob, self->prev_rect,
+      cv::TermCriteria(CV_TERMCRIT_EPS | CV_TERMCRIT_ITER, 10, 1));
+
+  cv::Rect bounds = r.boundingRect();
+  if (bounds.x >= 0 && bounds.y >= 0 && bounds.width > 1 && bounds.height > 1) {
     self->prev_rect = bounds;
   } else {
-    //printf("CRAP> %i %i %i %i ;", self->prev_rect.x, self->prev_rect.y, self->prev_rect.width, self->prev_rect.height);
-    
-    // We have encountered a bug in opencv. Somehow the prev_rect has got mangled, so we 
-    // must reset it to a good value.
+    // printf("CRAP> %i %i %i %i ;", self->prev_rect.x, self->prev_rect.y,
+    //     self->prev_rect.width, self->prev_rect.height);
+
+    // We have encountered a bug in opencv. Somehow the prev_rect has got
+    // mangled, so we must reset it to a good value.
     self->prev_rect = backup_prev_rect;
   }
 
   v8::Local<v8::Array> arr = NanNew<Array>(4);
-
 
   arr->Set(0, NanNew<Number>(bounds.x));
   arr->Set(1, NanNew<Number>(bounds.y));
@@ -180,12 +166,10 @@ NAN_METHOD(TrackedObject::Track){
   cv::Point2f pts[4];
   r.points(pts);
 
-  for (int i=0; i<8; i+=2){
+  for (int i = 0; i < 8; i += 2) {
     arr->Set(i, NanNew<Number>(pts[i].x));
-    arr->Set(i+1, NanNew<Number>(pts[i].y));
-  }
-*/
+    arr->Set(i + 1, NanNew<Number>(pts[i].y));
+  } */
 
-	NanReturnValue(arr);
-
+  NanReturnValue(arr);
 }

--- a/src/CamShift.h
+++ b/src/CamShift.h
@@ -2,22 +2,21 @@
 
 
 class TrackedObject: public node::ObjectWrap {
-  public:
-    int channel;
-    cv::Mat hsv;
-    cv::Mat hue;
-    cv::Mat mask;
-    cv::Mat prob;
+public:
+  int channel;
+  cv::Mat hsv;
+  cv::Mat hue;
+  cv::Mat mask;
+  cv::Mat prob;
 
-    cv::Mat hist;
-    cv::Rect prev_rect;
+  cv::Mat hist;
+  cv::Rect prev_rect;
 
-	  static Persistent<FunctionTemplate> constructor;
-	  static void Init(Handle<Object> target);
-    static NAN_METHOD(New);
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(New);
 
-	  TrackedObject(cv::Mat image, cv::Rect rect, int channel);
+  TrackedObject(cv::Mat image, cv::Rect rect, int channel);
 
-    JSFUNC(Track);
-
+  JSFUNC(Track);
 };

--- a/src/CascadeClassifierWrap.cc
+++ b/src/CascadeClassifierWrap.cc
@@ -3,89 +3,94 @@
 #include "Matrix.h"
 #include <nan.h>
 
-
 Persistent<FunctionTemplate> CascadeClassifierWrap::constructor;
 
-void
-CascadeClassifierWrap::Init(Handle<Object> target) {
-    NanScope();
+void CascadeClassifierWrap::Init(Handle<Object> target) {
+  NanScope();
 
-    Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(CascadeClassifierWrap::New);
-    NanAssignPersistent(constructor, ctor);
-    ctor->InstanceTemplate()->SetInternalFieldCount(1);
-    ctor->SetClassName(NanNew("CascadeClassifier"));
+  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate> (CascadeClassifierWrap::New);
+  NanAssignPersistent(constructor, ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(NanNew("CascadeClassifier"));
 
-    // Prototype
-    //Local<ObjectTemplate> proto = constructor->PrototypeTemplate();
+  // Prototype
+  // Local<ObjectTemplate> proto = constructor->PrototypeTemplate();
 
-    NODE_SET_PROTOTYPE_METHOD(ctor, "detectMultiScale", DetectMultiScale);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "detectMultiScale", DetectMultiScale);
 
-    target->Set(NanNew("CascadeClassifier"), ctor->GetFunction());
-};
+  target->Set(NanNew("CascadeClassifier"), ctor->GetFunction());
+}
 
 NAN_METHOD(CascadeClassifierWrap::New) {
   NanScope();
 
-  if (args.This()->InternalFieldCount() == 0)
+  if (args.This()->InternalFieldCount() == 0) {
     NanThrowTypeError("Cannot instantiate without new");
+  }
 
   CascadeClassifierWrap *pt = new CascadeClassifierWrap(*args[0]);
   pt->Wrap(args.This());
   NanReturnValue( args.This() );
 }
 
+CascadeClassifierWrap::CascadeClassifierWrap(v8::Value* fileName) {
+  std::string filename;
+  filename = std::string(*NanAsciiString(fileName->ToString()));
 
-CascadeClassifierWrap::CascadeClassifierWrap(v8::Value* fileName){
-	std::string filename;
-	filename = std::string(*NanAsciiString(fileName->ToString()));
-
-
-  if (!cc.load(filename.c_str())){
+  if (!cc.load(filename.c_str())) {
     NanThrowTypeError("Error loading file");
   }
 }
 
+class AsyncDetectMultiScale: public NanAsyncWorker {
+public:
+  AsyncDetectMultiScale(NanCallback *callback, CascadeClassifierWrap *cc,
+      Matrix* im, double scale, int neighbors, int minw, int minh) :
+      NanAsyncWorker(callback),
+      cc(cc),
+      im(im),
+      scale(scale),
+      neighbors(neighbors),
+      minw(minw),
+      minh(minh) {
+  }
+  
+  ~AsyncDetectMultiScale() {
+  }
 
-
-
-class AsyncDetectMultiScale : public NanAsyncWorker {
- public:
-  AsyncDetectMultiScale(NanCallback *callback, CascadeClassifierWrap *cc, Matrix* im, double scale, int neighbors,  int minw, int minh) : NanAsyncWorker(callback), cc(cc), im(im), scale(scale), neighbors(neighbors), minw(minw), minh(minh)  {}
-  ~AsyncDetectMultiScale() {}
-
-  void Execute () {
+  void Execute() {
     try {
-      std::vector<cv::Rect> objects;
+      std::vector < cv::Rect > objects;
 
       cv::Mat gray;
 
-      if(this->im->mat.channels() != 1) {
+      if (this->im->mat.channels() != 1) {
         cvtColor(this->im->mat, gray, CV_BGR2GRAY);
-        equalizeHist( gray, gray);
+        equalizeHist(gray, gray);
       } else {
         gray = this->im->mat;
       }
-      this->cc->cc.detectMultiScale(gray, objects, this->scale, this->neighbors, 0 | CV_HAAR_SCALE_IMAGE, cv::Size(this->minw, this->minh));
+      this->cc->cc.detectMultiScale(gray, objects, this->scale, this->neighbors,
+          0 | CV_HAAR_SCALE_IMAGE, cv::Size(this->minw, this->minh));
       res = objects;
-    }
-    catch( cv::Exception& e ){
+    } catch (cv::Exception& e) {
       SetErrorMessage(e.what());
     }
   }
 
-  void HandleOKCallback () {
+  void HandleOKCallback() {
     NanScope();
     //  this->matrix->Unref();
 
-    Handle<Value> argv[2];
-    v8::Local<v8::Array> arr = NanNew<v8::Array>(this->res.size());
+    Handle < Value > argv[2];
+    v8::Local < v8::Array > arr = NanNew < v8::Array > (this->res.size());
 
-    for(unsigned int i = 0; i < this->res.size(); i++ ){
-      v8::Local<v8::Object> x = NanNew<v8::Object>();
-      x->Set(NanNew("x"), NanNew<Number>(this->res[i].x));
-      x->Set(NanNew("y"), NanNew<Number>(this->res[i].y));
-      x->Set(NanNew("width"), NanNew<Number>(this->res[i].width));
-      x->Set(NanNew("height"), NanNew<Number>(this->res[i].height));
+    for (unsigned int i = 0; i < this->res.size(); i++) {
+      v8::Local < v8::Object > x = NanNew<v8::Object>();
+      x->Set(NanNew("x"), NanNew < Number > (this->res[i].x));
+      x->Set(NanNew("y"), NanNew < Number > (this->res[i].y));
+      x->Set(NanNew("width"), NanNew < Number > (this->res[i].width));
+      x->Set(NanNew("height"), NanNew < Number > (this->res[i].height));
       arr->Set(i, x);
     }
 
@@ -97,54 +102,50 @@ class AsyncDetectMultiScale : public NanAsyncWorker {
     if (try_catch.HasCaught()) {
       FatalException(try_catch);
     }
-
   }
 
-  private:
-    CascadeClassifierWrap *cc;
-    Matrix* im;
-    double scale;
-    int neighbors;
-    int minw;
-    int minh;
-    std::vector<cv::Rect>  res;
-
+private:
+  CascadeClassifierWrap *cc;
+  Matrix* im;
+  double scale;
+  int neighbors;
+  int minw;
+  int minh;
+  std::vector<cv::Rect> res;
 };
 
-
-
-
-NAN_METHOD(CascadeClassifierWrap::DetectMultiScale){
+NAN_METHOD(CascadeClassifierWrap::DetectMultiScale) {
   NanScope();
 
-  CascadeClassifierWrap *self =  ObjectWrap::Unwrap<CascadeClassifierWrap>(args.This());
+  CascadeClassifierWrap *self = ObjectWrap::Unwrap<CascadeClassifierWrap> (args.This());
 
-  if (args.Length() < 2){
+  if (args.Length() < 2) {
     NanThrowTypeError("detectMultiScale takes at least 2 args");
   }
 
-  Matrix *im = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+  Matrix *im = ObjectWrap::Unwrap < Matrix > (args[0]->ToObject());
   REQ_FUN_ARG(1, cb);
 
   double scale = 1.1;
-  if (args.Length() > 2 && args[2]->IsNumber())
+  if (args.Length() > 2 && args[2]->IsNumber()) {
     scale = args[2]->NumberValue();
+  }
 
   int neighbors = 2;
-  if (args.Length() > 3 && args[3]->IsInt32())
+  if (args.Length() > 3 && args[3]->IsInt32()) {
     neighbors = args[3]->IntegerValue();
+  }
 
   int minw = 30;
   int minh = 30;
-  if (args.Length() > 5 && args[4]->IsInt32() && args[5]->IsInt32()){
+  if (args.Length() > 5 && args[4]->IsInt32() && args[5]->IsInt32()) {
     minw = args[4]->IntegerValue();
     minh = args[5]->IntegerValue();
   }
 
-
   NanCallback *callback = new NanCallback(cb.As<Function>());
 
-  NanAsyncQueueWorker( new AsyncDetectMultiScale(callback, self, im, scale, neighbors, minw, minh) );
+  NanAsyncQueueWorker( new AsyncDetectMultiScale(callback, self, im, scale,
+          neighbors, minw, minh));
   NanReturnUndefined();
-
 }

--- a/src/CascadeClassifierWrap.h
+++ b/src/CascadeClassifierWrap.h
@@ -1,20 +1,19 @@
 #include "OpenCV.h"
 
 class CascadeClassifierWrap: public node::ObjectWrap {
-  public: 
- 	cv::CascadeClassifier cc;
+public:
+  cv::CascadeClassifier cc;
 
-	static Persistent<FunctionTemplate> constructor;
-	static void Init(Handle<Object> target);
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
   static NAN_METHOD(New);
 
-	CascadeClassifierWrap(v8::Value* fileName);   
+  CascadeClassifierWrap(v8::Value* fileName);
 
   //static Handle<Value> LoadHaarClassifierCascade(const v8::Arguments&);
 
   static NAN_METHOD(DetectMultiScale);
 
-	static void EIO_DetectMultiScale(uv_work_t *req);
-	static int EIO_AfterDetectMultiScale(uv_work_t *req);
-
+  static void EIO_DetectMultiScale(uv_work_t *req);
+  static int EIO_AfterDetectMultiScale(uv_work_t *req);
 };

--- a/src/Constants.cc
+++ b/src/Constants.cc
@@ -5,10 +5,9 @@
   obj->Set(NanNew<String>(#C), NanNew<Integer>(C));
 
 #define CONST_ENUM(C) \
-    obj->Set(NanNew<String>(#C), NanNew<Integer>((int)(cv::C)));
+  obj->Set(NanNew<String>(#C), NanNew<Integer>((int)(cv::C)));
 
-void
-Constants::Init(Handle<Object> target) {
+void Constants::Init(Handle<Object> target) {
   Persistent<Object> inner;
   Local<Object> obj = NanNew<Object>();
   NanAssignPersistent(inner, obj);

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -1,6 +1,6 @@
 #include "OpenCV.h"
 
 class Constants: public node::ObjectWrap {
- public:
-    static void Init(Handle<Object> target);
+public:
+  static void Init(Handle<Object> target);
 };

--- a/src/Contours.cc
+++ b/src/Contours.cc
@@ -6,81 +6,77 @@
 
 v8::Persistent<FunctionTemplate> Contour::constructor;
 
+void Contour::Init(Handle<Object> target) {
+  NanScope();
 
-void
-Contour::Init(Handle<Object> target) {
-	NanScope();
-
-	//Class/contructor
-	Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(Contour::New);
+  // Class/contructor
+  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(Contour::New);
   NanAssignPersistent(constructor, ctor);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
   ctor->SetClassName(NanNew("Contours"));
-	
 
-	// Prototype
-	//Local<ObjectTemplate> proto = constructor->PrototypeTemplate();
-	NODE_SET_PROTOTYPE_METHOD(ctor, "point", Point);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "size", Size);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "cornerCount", CornerCount);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "area", Area);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "arcLength", ArcLength);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "approxPolyDP", ApproxPolyDP);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "convexHull", ConvexHull);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "boundingRect", BoundingRect);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "minAreaRect", MinAreaRect);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "fitEllipse", FitEllipse);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "isConvex", IsConvex);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "moments", Moments);
+  // Prototype
+  // Local<ObjectTemplate> proto = constructor->PrototypeTemplate();
+  NODE_SET_PROTOTYPE_METHOD(ctor, "point", Point);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "size", Size);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "cornerCount", CornerCount);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "area", Area);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "arcLength", ArcLength);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "approxPolyDP", ApproxPolyDP);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "convexHull", ConvexHull);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "boundingRect", BoundingRect);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "minAreaRect", MinAreaRect);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "fitEllipse", FitEllipse);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "isConvex", IsConvex);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "moments", Moments);
   NODE_SET_PROTOTYPE_METHOD(ctor, "hierarchy", Hierarchy);
   NODE_SET_PROTOTYPE_METHOD(ctor, "serialize", Serialize);
   NODE_SET_PROTOTYPE_METHOD(ctor, "deserialize", Deserialize);
-	target->Set(NanNew("Contours"), ctor->GetFunction());
+  target->Set(NanNew("Contours"), ctor->GetFunction());
 };
-
 
 NAN_METHOD(Contour::New) {
   NanScope();
 
-	if (args.This()->InternalFieldCount() == 0)
+  if (args.This()->InternalFieldCount() == 0) {
     NanThrowTypeError("Cannot instantiate without new");
+  }
 
-	Contour *contours;
-	contours = new Contour;
+  Contour *contours;
+  contours = new Contour;
 
-	contours->Wrap(args.Holder());
-	NanReturnValue(args.Holder());
+  contours->Wrap(args.Holder());
+  NanReturnValue(args.Holder());
 }
 
-
-Contour::Contour(): ObjectWrap() {
+Contour::Contour() :
+    ObjectWrap() {
 }
 
 NAN_METHOD(Contour::Point) {
-	 NanScope();
+  NanScope();
 
-		Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-		int pos   = args[0]->NumberValue();
-		int index = args[1]->NumberValue();
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  int pos = args[0]->NumberValue();
+  int index = args[1]->NumberValue();
 
-		cv::Point point = self->contours[pos][index];
+  cv::Point point = self->contours[pos][index];
 
-		Local<Object> data = NanNew<Object>();
-		data->Set(NanNew("x"), NanNew<Number>(point.x));
-		data->Set(NanNew("y"), NanNew<Number>(point.y));
+  Local<Object> data = NanNew<Object>();
+  data->Set(NanNew("x"), NanNew<Number>(point.x));
+  data->Set(NanNew("y"), NanNew<Number>(point.y));
 
-		NanReturnValue(data);
+  NanReturnValue(data);
 }
 
 NAN_METHOD(Contour::Points) {
-   NanScope();
+  NanScope();
 
   Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-  int pos   = args[0]->NumberValue();
+  int pos = args[0]->NumberValue();
 
   vector<cv::Point> points = self->contours[pos];
-
-  Local<Array> data = NanNew<Array>(points.size());  
+  Local<Array> data = NanNew<Array>(points.size());
 
   for (std::vector<int>::size_type i = 0; i != points.size(); i++) {
     Local<Object> point_data = NanNew<Object>();
@@ -93,204 +89,194 @@ NAN_METHOD(Contour::Points) {
   NanReturnValue(data);
 }
 
-// FIXME: this sould better be called "Length" as ``Contours`` is an Array like structure
-// also, this would allow to use ``Size`` for the function returning the number of corners
-// in the contour for better consistency with OpenCV.
+// FIXME: this should better be called "Length" as ``Contours`` is an Array like
+// structure also, this would allow to use ``Size`` for the function returning
+// the number of corners in the contour for better consistency with OpenCV.
 NAN_METHOD(Contour::Size) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
 
-	NanReturnValue(NanNew<Number>(self->contours.size()));
+  NanReturnValue(NanNew<Number>(self->contours.size()));
 }
-
 
 NAN_METHOD(Contour::CornerCount) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-	int pos = args[0]->NumberValue();
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  int pos = args[0]->NumberValue();
 
-	NanReturnValue(NanNew<Number>(self->contours[pos].size()));
+  NanReturnValue(NanNew<Number>(self->contours[pos].size()));
 }
-
 
 NAN_METHOD(Contour::Area) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-	int pos = args[0]->NumberValue();
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  int pos = args[0]->NumberValue();
 
-	//NanReturnValue(NanNew<Number>(contourArea(self->contours)));
-	NanReturnValue(NanNew<Number>(contourArea(cv::Mat(self->contours[pos]))));
+  // NanReturnValue(NanNew<Number>(contourArea(self->contours)));
+  NanReturnValue(NanNew<Number>(contourArea(cv::Mat(self->contours[pos]))));
 }
-
 
 NAN_METHOD(Contour::ArcLength) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-	int pos = args[0]->NumberValue();
-	bool isClosed = args[1]->BooleanValue();
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  int pos = args[0]->NumberValue();
+  bool isClosed = args[1]->BooleanValue();
 
-	NanReturnValue(NanNew<Number>(arcLength(cv::Mat(self->contours[pos]), isClosed)));
+  NanReturnValue(NanNew<Number>(arcLength(cv::Mat(self->contours[pos]), isClosed)));
 }
-
 
 NAN_METHOD(Contour::ApproxPolyDP) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-	int pos = args[0]->NumberValue();
-	double epsilon = args[1]->NumberValue();
-	bool isClosed = args[2]->BooleanValue();
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  int pos = args[0]->NumberValue();
+  double epsilon = args[1]->NumberValue();
+  bool isClosed = args[2]->BooleanValue();
 
-	cv::Mat approxed;
-	approxPolyDP(cv::Mat(self->contours[pos]), approxed, epsilon, isClosed);
-	approxed.copyTo(self->contours[pos]);
+  cv::Mat approxed;
+  approxPolyDP(cv::Mat(self->contours[pos]), approxed, epsilon, isClosed);
+  approxed.copyTo(self->contours[pos]);
 
-	NanReturnNull();
+  NanReturnNull();
 }
-
 
 NAN_METHOD(Contour::ConvexHull) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
 
-	int pos        = args[0]->NumberValue();
-	bool clockwise = args[1]->BooleanValue();
+  int pos = args[0]->NumberValue();
+  bool clockwise = args[1]->BooleanValue();
 
-	cv::Mat hull;
-	cv::convexHull(cv::Mat(self->contours[pos]), hull, clockwise);
-	hull.copyTo(self->contours[pos]);
+  cv::Mat hull;
+  cv::convexHull(cv::Mat(self->contours[pos]), hull, clockwise);
+  hull.copyTo(self->contours[pos]);
 
-	NanReturnNull();
+  NanReturnNull();
 }
-
 
 NAN_METHOD(Contour::BoundingRect) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-	int pos = args[0]->NumberValue();
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  int pos = args[0]->NumberValue();
 
-	cv::Rect bounding =	cv::boundingRect(cv::Mat(self->contours[pos]));
-	Local<Object> rect = NanNew<Object>();
+  cv::Rect bounding = cv::boundingRect(cv::Mat(self->contours[pos]));
+  Local<Object> rect = NanNew<Object>();
 
-	rect->Set(NanNew("x"), NanNew<Number>(bounding.x));
-	rect->Set(NanNew("y"), NanNew<Number>(bounding.y));
-	rect->Set(NanNew("width"), NanNew<Number>(bounding.width));
-	rect->Set(NanNew("height"), NanNew<Number>(bounding.height));
+  rect->Set(NanNew("x"), NanNew<Number>(bounding.x));
+  rect->Set(NanNew("y"), NanNew<Number>(bounding.y));
+  rect->Set(NanNew("width"), NanNew<Number>(bounding.width));
+  rect->Set(NanNew("height"), NanNew<Number>(bounding.height));
 
-	NanReturnValue(rect);
+  NanReturnValue(rect);
 }
-
 
 NAN_METHOD(Contour::MinAreaRect) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-	int pos = args[0]->NumberValue();
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  int pos = args[0]->NumberValue();
 
-	cv::RotatedRect minimum = cv::minAreaRect(cv::Mat(self->contours[pos]));
+  cv::RotatedRect minimum = cv::minAreaRect(cv::Mat(self->contours[pos]));
 
-	Local<Object> rect = NanNew<Object>();
-	rect->Set(NanNew("angle"), NanNew<Number>(minimum.angle));
+  Local<Object> rect = NanNew<Object>();
+  rect->Set(NanNew("angle"), NanNew<Number>(minimum.angle));
 
-	Local<Object> size = NanNew<Object>();
-	size->Set(NanNew("height"), NanNew<Number>(minimum.size.height));
-	size->Set(NanNew("width"), NanNew<Number>(minimum.size.width));
-	rect->Set(NanNew("size"), size);
+  Local<Object> size = NanNew<Object>();
+  size->Set(NanNew("height"), NanNew<Number>(minimum.size.height));
+  size->Set(NanNew("width"), NanNew<Number>(minimum.size.width));
+  rect->Set(NanNew("size"), size);
 
-	Local<Object> center = NanNew<Object>();
-	center->Set(NanNew("x"), NanNew<Number>(minimum.center.x));
-	center->Set(NanNew("y"), NanNew<Number>(minimum.center.y));
+  Local<Object> center = NanNew<Object>();
+  center->Set(NanNew("x"), NanNew<Number>(minimum.center.x));
+  center->Set(NanNew("y"), NanNew<Number>(minimum.center.y));
 
-	v8::Local<v8::Array> points = NanNew<Array>(4);
+  v8::Local<v8::Array> points = NanNew<Array>(4);
 
-	cv::Point2f rect_points[4];
-	minimum.points(rect_points);
+  cv::Point2f rect_points[4];
+  minimum.points(rect_points);
 
-	for (unsigned int i=0; i<4; i++){
-		Local<Object> point = NanNew<Object>();
-		point->Set(NanNew("x"), NanNew<Number>(rect_points[i].x));
-		point->Set(NanNew("y"), NanNew<Number>(rect_points[i].y));
-		points->Set(i, point);
-	}
+  for (unsigned int i=0; i<4; i++) {
+    Local<Object> point = NanNew<Object>();
+    point->Set(NanNew("x"), NanNew<Number>(rect_points[i].x));
+    point->Set(NanNew("y"), NanNew<Number>(rect_points[i].y));
+    points->Set(i, point);
+  }
 
-	rect->Set(NanNew("points"), points);
+  rect->Set(NanNew("points"), points);
 
-	NanReturnValue(rect);
+  NanReturnValue(rect);
 }
-
 
 NAN_METHOD(Contour::FitEllipse) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-	int pos = args[0]->NumberValue();
-	
-	if(self->contours[pos].size() >= 5){  //Minimum number for an ellipse
-		cv::RotatedRect ellipse = cv::fitEllipse(cv::Mat(self->contours[pos]));
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  int pos = args[0]->NumberValue();
 
-		Local<Object> jsEllipse = NanNew<Object>();
-		jsEllipse->Set(NanNew("angle"), NanNew<Number>(ellipse.angle));
+  if (self->contours[pos].size() >= 5) {  // Minimum number for an ellipse
+    cv::RotatedRect ellipse = cv::fitEllipse(cv::Mat(self->contours[pos]));
 
-		Local<Object> size = NanNew<Object>();
-		size->Set(NanNew("height"), NanNew<Number>(ellipse.size.height));
-		size->Set(NanNew("width"), NanNew<Number>(ellipse.size.width));
-		jsEllipse->Set(NanNew("size"), size);
+    Local<Object> jsEllipse = NanNew<Object>();
+    jsEllipse->Set(NanNew("angle"), NanNew<Number>(ellipse.angle));
 
-		Local<Object> center = NanNew<Object>();
-		center->Set(NanNew("x"), NanNew<Number>(ellipse.center.x));
-		center->Set(NanNew("y"), NanNew<Number>(ellipse.center.y));
-		jsEllipse->Set(NanNew("center"), center);
+    Local<Object> size = NanNew<Object>();
+    size->Set(NanNew("height"), NanNew<Number>(ellipse.size.height));
+    size->Set(NanNew("width"), NanNew<Number>(ellipse.size.width));
+    jsEllipse->Set(NanNew("size"), size);
 
-		NanReturnValue(jsEllipse);
-	}
+    Local<Object> center = NanNew<Object>();
+    center->Set(NanNew("x"), NanNew<Number>(ellipse.center.x));
+    center->Set(NanNew("y"), NanNew<Number>(ellipse.center.y));
+    jsEllipse->Set(NanNew("center"), center);
 
-	NanReturnNull();
+    NanReturnValue(jsEllipse);
+  }
+
+  NanReturnNull();
 }
 
-
-
 NAN_METHOD(Contour::IsConvex) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-	int pos = args[0]->NumberValue();
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  int pos = args[0]->NumberValue();
 
-	NanReturnValue(NanNew<Boolean>(isContourConvex(cv::Mat(self->contours[pos]))));
+  NanReturnValue(NanNew<Boolean>(isContourConvex(cv::Mat(self->contours[pos]))));
 }
 
 NAN_METHOD(Contour::Moments) {
-	 NanScope();
+  NanScope();
 
-	Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
-	int pos = args[0]->NumberValue();
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
+  int pos = args[0]->NumberValue();
 
-	/// Get the moments
-	cv::Moments mu = moments( self->contours[pos], false );
-    
-	Local<Object> res = NanNew<Object>();
+  // Get the moments
+  cv::Moments mu = moments( self->contours[pos], false );
 
-	res->Set(NanNew("m00"), NanNew<Number>(mu.m00));
-	res->Set(NanNew("m10"), NanNew<Number>(mu.m10));
-	res->Set(NanNew("m01"), NanNew<Number>(mu.m01));
-	res->Set(NanNew("m11"), NanNew<Number>(mu.m11));
+  Local<Object> res = NanNew<Object>();
 
-	NanReturnValue(res);
+  res->Set(NanNew("m00"), NanNew<Number>(mu.m00));
+  res->Set(NanNew("m10"), NanNew<Number>(mu.m10));
+  res->Set(NanNew("m01"), NanNew<Number>(mu.m01));
+  res->Set(NanNew("m11"), NanNew<Number>(mu.m11));
+
+  NanReturnValue(res);
 }
 
 NAN_METHOD(Contour::Hierarchy) {
-   NanScope();
+  NanScope();
 
   Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
   int pos = args[0]->IntegerValue();
 
   cv::Vec4i hierarchy = self->hierarchy[pos];
-    
+
   Local<Array> res = NanNew<Array>(4);
 
   res->Set(0, NanNew<Number>(hierarchy[0]));
@@ -302,12 +288,12 @@ NAN_METHOD(Contour::Hierarchy) {
 }
 
 NAN_METHOD(Contour::Serialize) {
-   NanScope();
+  NanScope();
 
-  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());  
+  Contour *self = ObjectWrap::Unwrap<Contour>(args.This());
 
   Local<Array> contours_data = NanNew<Array>(self->contours.size());
-  
+
   for (std::vector<int>::size_type i = 0; i != self->contours.size(); i++) {
     vector<cv::Point> points = self->contours[i];
     Local<Array> contour_data = NanNew<Array>(points.size());
@@ -319,8 +305,7 @@ NAN_METHOD(Contour::Serialize) {
 
       contour_data->Set(j, point_data);
     }
-
-    contours_data->Set(i, contour_data);    
+    contours_data->Set(i, contour_data);
   }
 
   Local<Array> hierarchy_data = NanNew<Array>(self->hierarchy.size());
@@ -383,6 +368,6 @@ NAN_METHOD(Contour::Deserialize) {
 
   self->contours = contours_res;
   self->hierarchy = hierarchy_res;
-  
+
   NanReturnNull();
 }

--- a/src/Contours.h
+++ b/src/Contours.h
@@ -3,20 +3,19 @@
 using namespace std;
 
 class Contour: public node::ObjectWrap {
-	public:
-
-	cv::Mat mat;
-	vector<vector<cv::Point> > contours;
+public:
+  cv::Mat mat;
+  vector<vector<cv::Point> > contours;
   vector<cv::Vec4i> hierarchy;
 
   static Persistent<FunctionTemplate> constructor;
-	static void Init(Handle<Object> target);
+  static void Init(Handle<Object> target);
   static NAN_METHOD(New);
 
-	Contour();
+  Contour();
 
-	JSFUNC(Point)
-	JSFUNC(Points)
+  JSFUNC(Point)
+  JSFUNC(Points)
   JSFUNC(Size)
   JSFUNC(CornerCount)
   JSFUNC(Area)

--- a/src/FaceRecognizer.h
+++ b/src/FaceRecognizer.h
@@ -1,41 +1,38 @@
 #include "OpenCV.h"
 
-#if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4
+#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
 
 #include "opencv2/contrib/contrib.hpp"
 
 class FaceRecognizerWrap: public node::ObjectWrap {
-  public:
-    cv::Ptr<cv::FaceRecognizer> rec;
-    int typ;
+public:
+  cv::Ptr<cv::FaceRecognizer> rec;
+  int typ;
 
-    static Persistent<FunctionTemplate> constructor;
-    static void Init(Handle<Object> target);
-    static NAN_METHOD(New);
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(New);
 
-    FaceRecognizerWrap(cv::Ptr<cv::FaceRecognizer> f, int type);
+  FaceRecognizerWrap(cv::Ptr<cv::FaceRecognizer> f, int type);
 
-    JSFUNC(CreateLBPH)
-    JSFUNC(CreateEigen)
-    JSFUNC(CreateFisher)
-    
-    JSFUNC(TrainSync)
-    //JSFUNC(Train)
-    JSFUNC(UpdateSync)
-    //JSFUNC(Update)
-    
-    JSFUNC(PredictSync)
-    // JSFUNC(Predict)
-    //static void EIO_Predict(eio_req *req);
-    //static int EIO_AfterPredict(eio_req *req);
+  JSFUNC(CreateLBPH)
+  JSFUNC(CreateEigen)
+  JSFUNC(CreateFisher)
 
+  JSFUNC(TrainSync)
+  //JSFUNC(Train)
+  JSFUNC(UpdateSync)
+  //JSFUNC(Update)
 
-    JSFUNC(SaveSync)
-    JSFUNC(LoadSync)
-    
-    JSFUNC(GetMat)
+  JSFUNC(PredictSync)
+  // JSFUNC(Predict)
+  //static void EIO_Predict(eio_req *req);
+  //static int EIO_AfterPredict(eio_req *req);
+
+  JSFUNC(SaveSync)
+  JSFUNC(LoadSync)
+
+  JSFUNC(GetMat)
 };
-
-
 
 #endif

--- a/src/Features2d.cc
+++ b/src/Features2d.cc
@@ -3,72 +3,83 @@
 #include <nan.h>
 #include <stdio.h>
 
-#if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4
+#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
 
-void
-Features::Init(Handle<Object> target) {
+void Features::Init(Handle<Object> target) {
   NanScope();
 
   NODE_SET_METHOD(target, "ImageSimilarity", Similarity);
-};
+}
 
-class AsyncDetectSimilarity : public NanAsyncWorker {
- public:
-  AsyncDetectSimilarity(NanCallback *callback, cv::Mat image1, cv::Mat image2) : NanAsyncWorker(callback), image1(image1), image2(image2), dissimilarity(0) {}
-  ~AsyncDetectSimilarity() {}
-
-  void Execute () {
-
-      cv::Ptr<cv::FeatureDetector> detector = cv::FeatureDetector::create("ORB");
-      cv::Ptr<cv::DescriptorExtractor> extractor = cv::DescriptorExtractor::create("ORB");
-      cv::Ptr<cv::DescriptorMatcher> matcher = cv::DescriptorMatcher::create("BruteForce-Hamming");
-
-      std::vector<cv::DMatch> matches;
-
-      cv::Mat descriptors1 = cv::Mat();
-      cv::Mat descriptors2 = cv::Mat();
-
-      std::vector<cv::KeyPoint> keypoints1;
-      std::vector<cv::KeyPoint> keypoints2;
-
-      detector->detect(image1, keypoints1);
-      detector->detect(image2, keypoints2);
-
-      extractor->compute(image1, keypoints1, descriptors1);
-      extractor->compute(image2, keypoints2, descriptors2);
-
-      matcher->match(descriptors1, descriptors2, matches);
-
-      double max_dist = 0;
-      double min_dist = 100;
-
-      //-- Quick calculation of max and min distances between keypoints
-      for (int i = 0; i < descriptors1.rows; i++) {
-        double dist = matches[i].distance;
-        if( dist < min_dist ) min_dist = dist;
-        if( dist > max_dist ) max_dist = dist;
-      }
-
-      //-- Draw only "good" matches (i.e. whose distance is less than 2*min_dist,
-      //-- or a small arbitary value ( 0.02 ) in the event that min_dist is very
-      //-- small)
-      //-- PS.- radiusMatch can also be used here.
-      std::vector<cv::DMatch> good_matches;
-      double good_matches_sum = 0.0;
-
-      for (int i = 0; i < descriptors1.rows; i++ ) {
-        double distance = matches[i].distance;
-        if (distance <= std::max(2*min_dist, 0.02)) {
-          good_matches.push_back(matches[i]);
-          good_matches_sum += distance;
-        }
-      }
-
-      dissimilarity = (double)good_matches_sum / (double)good_matches.size();
-
+class AsyncDetectSimilarity: public NanAsyncWorker {
+public:
+  AsyncDetectSimilarity(NanCallback *callback, cv::Mat image1, cv::Mat image2) :
+      NanAsyncWorker(callback),
+      image1(image1),
+      image2(image2),
+      dissimilarity(0) {
   }
 
-  void HandleOKCallback () {
+  ~AsyncDetectSimilarity() {
+  }
+
+  void Execute() {
+
+    cv::Ptr<cv::FeatureDetector> detector = cv::FeatureDetector::create("ORB");
+    cv::Ptr<cv::DescriptorExtractor> extractor =
+        cv::DescriptorExtractor::create("ORB");
+    cv::Ptr<cv::DescriptorMatcher> matcher = cv::DescriptorMatcher::create(
+        "BruteForce-Hamming");
+
+    std::vector<cv::DMatch> matches;
+
+    cv::Mat descriptors1 = cv::Mat();
+    cv::Mat descriptors2 = cv::Mat();
+
+    std::vector<cv::KeyPoint> keypoints1;
+    std::vector<cv::KeyPoint> keypoints2;
+
+    detector->detect(image1, keypoints1);
+    detector->detect(image2, keypoints2);
+
+    extractor->compute(image1, keypoints1, descriptors1);
+    extractor->compute(image2, keypoints2, descriptors2);
+
+    matcher->match(descriptors1, descriptors2, matches);
+
+    double max_dist = 0;
+    double min_dist = 100;
+
+    //-- Quick calculation of max and min distances between keypoints
+    for (int i = 0; i < descriptors1.rows; i++) {
+      double dist = matches[i].distance;
+      if (dist < min_dist) {
+        min_dist = dist;
+      }
+      if (dist > max_dist) {
+        max_dist = dist;
+      }
+    }
+
+    //-- Draw only "good" matches (i.e. whose distance is less than 2*min_dist,
+    //-- or a small arbitary value ( 0.02 ) in the event that min_dist is very
+    //-- small)
+    //-- PS.- radiusMatch can also be used here.
+    std::vector<cv::DMatch> good_matches;
+    double good_matches_sum = 0.0;
+
+    for (int i = 0; i < descriptors1.rows; i++) {
+      double distance = matches[i].distance;
+      if (distance <= std::max(2 * min_dist, 0.02)) {
+        good_matches.push_back(matches[i]);
+        good_matches_sum += distance;
+      }
+    }
+
+    dissimilarity = (double) good_matches_sum / (double) good_matches.size();
+  }
+
+  void HandleOKCallback() {
     NanScope();
 
     Handle<Value> argv[2];
@@ -77,14 +88,12 @@ class AsyncDetectSimilarity : public NanAsyncWorker {
     argv[1] = NanNew<Number>(dissimilarity);
 
     callback->Call(2, argv);
-
   }
 
-  private:
-    cv::Mat image1;
-    cv::Mat image2;
-    double dissimilarity;
-
+private:
+  cv::Mat image1;
+  cv::Mat image2;
+  double dissimilarity;
 };
 
 NAN_METHOD(Features::Similarity) {
@@ -99,7 +108,6 @@ NAN_METHOD(Features::Similarity) {
 
   NanAsyncQueueWorker( new AsyncDetectSimilarity(callback, image1, image2) );
   NanReturnUndefined();
-
-};
+}
 
 #endif

--- a/src/Features2d.h
+++ b/src/Features2d.h
@@ -1,16 +1,16 @@
 #include "OpenCV.h"
 
-#if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4
+#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/features2d/features2d.hpp>
 
 class Features: public node::ObjectWrap {
-  public:
-    static Persistent<FunctionTemplate> constructor;
-    static void Init(Handle<Object> target);
+public:
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
 
-    static NAN_METHOD(Similarity);
+  static NAN_METHOD(Similarity);
 };
 
 #endif

--- a/src/HighGUI.cc
+++ b/src/HighGUI.cc
@@ -2,89 +2,83 @@
 #include "OpenCV.h"
 #include "Matrix.h"
 
-
 Persistent<FunctionTemplate> NamedWindow::constructor;
 
-void
-NamedWindow::Init(Handle<Object> target) {
-    NanScope();
+void NamedWindow::Init(Handle<Object> target) {
+  NanScope();
 
-    // Constructor
-    Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(NamedWindow::New);
-    NanAssignPersistent(constructor, ctor);
-    ctor->InstanceTemplate()->SetInternalFieldCount(1);
-    ctor->SetClassName(NanNew("NamedWindow"));
+  // Constructor
+  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(NamedWindow::New);
+  NanAssignPersistent(constructor, ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(NanNew("NamedWindow"));
 
-    // Prototype
-	  NODE_SET_PROTOTYPE_METHOD(ctor, "show", Show);
-	  NODE_SET_PROTOTYPE_METHOD(ctor, "destroy", Destroy);
-	  NODE_SET_PROTOTYPE_METHOD(ctor, "blockingWaitKey", BlockingWaitKey);
-    
-    target->Set(NanNew("NamedWindow"), ctor->GetFunction());
+  // Prototype
+  NODE_SET_PROTOTYPE_METHOD(ctor, "show", Show);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "destroy", Destroy);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "blockingWaitKey", BlockingWaitKey);
+
+  target->Set(NanNew("NamedWindow"), ctor->GetFunction());
 };
-
 
 NAN_METHOD(NamedWindow::New) {
   NanScope();
 
-  if (args.This()->InternalFieldCount() == 0){
+  if (args.This()->InternalFieldCount() == 0) {
     JSTHROW_TYPE("Cannot Instantiate without new")
   }
 
   NamedWindow* win;
-	if (args.Length() == 1){
-		win = new NamedWindow(std::string(*NanAsciiString(args[0]->ToString())), 0);
-	} else { //if (args.Length() == 2){
-		win = new NamedWindow(std::string(*NanAsciiString(args[0]->ToString())), 0);
+  if (args.Length() == 1) {
+    win = new NamedWindow(std::string(*NanAsciiString(args[0]->ToString())), 0);
+  } else {  //if (args.Length() == 2){
+    win = new NamedWindow(std::string(*NanAsciiString(args[0]->ToString())), 0);
   }
 
-	win->Wrap(args.Holder());
-	NanReturnValue(args.Holder());
+  win->Wrap(args.Holder());
+  NanReturnValue(args.Holder());
 }
 
-
-NamedWindow::NamedWindow(const std::string& name, int f){
+NamedWindow::NamedWindow(const std::string& name, int f) {
   winname = std::string(name);
   flags = f;
   cv::namedWindow(winname, flags);
 }
 
-
-NAN_METHOD(NamedWindow::Show){
-	SETUP_FUNCTION(NamedWindow)
+NAN_METHOD(NamedWindow::Show) {
+  SETUP_FUNCTION(NamedWindow)
   Matrix *im = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
 
-  try{
+  try {
     cv::imshow(self->winname, im->mat);
-  } catch(cv::Exception& e ){
+  } catch (cv::Exception& e) {
     const char* err_msg = e.what();
     NanThrowError(err_msg);
   }
 
-	NanReturnValue(args.Holder());
+  NanReturnValue(args.Holder());
 }
 
-NAN_METHOD(NamedWindow::Destroy){
-	SETUP_FUNCTION(NamedWindow)
+NAN_METHOD(NamedWindow::Destroy) {
+  SETUP_FUNCTION(NamedWindow)
   cv::destroyWindow(self->winname);
-	NanReturnValue(args.Holder());
+  NanReturnValue(args.Holder());
 }
 
-
-NAN_METHOD(NamedWindow::BlockingWaitKey){
+NAN_METHOD(NamedWindow::BlockingWaitKey) {
   NanScope();
-	//SETUP_FUNCTION(NamedWindow)
-	int time = 0;
+  //SETUP_FUNCTION(NamedWindow)
+  int time = 0;
 
-  if (args.Length() > 1){
+  if (args.Length() > 1) {
     time = args[1]->IntegerValue();
-  }else{
-    if (args.Length() > 0){
+  } else {
+    if (args.Length() > 0) {
       time = args[0]->IntegerValue();
     }
   }
 
   int res = cv::waitKey(time);
 
-	NanReturnValue(NanNew<Number>(res));
+  NanReturnValue(NanNew<Number>(res));
 }

--- a/src/HighGUI.h
+++ b/src/HighGUI.h
@@ -1,19 +1,19 @@
 #include "OpenCV.h"
 
-
 class NamedWindow: public node::ObjectWrap {
-  public:
-    std::string winname;
-    int flags;
+public:
+  std::string winname;
+  int flags;
 
-	  static Persistent<FunctionTemplate> constructor;
-	  static void Init(Handle<Object> target);
-    static NAN_METHOD(New);
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(New);
 
-	  NamedWindow(const std::string& winname, int flags);
+  NamedWindow(const std::string& winname, int flags);
 
-    JSFUNC(Show);
-    JSFUNC(Destroy);
-    JSFUNC(BlockingWaitKey);
+  JSFUNC(Show)
+  ;JSFUNC(Destroy)
+  ;JSFUNC(BlockingWaitKey)
+  ;
 
 };

--- a/src/ImgProc.cc
+++ b/src/ImgProc.cc
@@ -1,169 +1,159 @@
 #include "ImgProc.h"
 #include "Matrix.h"
 
-void ImgProc::Init(Handle<Object> target)
-{
-    Persistent<Object> inner;
-    Local<Object> obj = NanNew<Object>();
-    NanAssignPersistent(inner, obj);
+void ImgProc::Init(Handle<Object> target) {
+  Persistent<Object> inner;
+  Local<Object> obj = NanNew<Object>();
+  NanAssignPersistent(inner, obj);
 
-    NODE_SET_METHOD(obj, "undistort", Undistort);
-    NODE_SET_METHOD(obj, "initUndistortRectifyMap", InitUndistortRectifyMap);
-    NODE_SET_METHOD(obj, "remap", Remap);
+  NODE_SET_METHOD(obj, "undistort", Undistort);
+  NODE_SET_METHOD(obj, "initUndistortRectifyMap", InitUndistortRectifyMap);
+  NODE_SET_METHOD(obj, "remap", Remap);
 
-    target->Set(NanNew("imgproc"), obj);
+  target->Set(NanNew("imgproc"), obj);
 }
 
 // cv::undistort
-NAN_METHOD(ImgProc::Undistort)
-{
-    NanEscapableScope();
+NAN_METHOD(ImgProc::Undistort) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg 0 is the image
-        Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-        cv::Mat inputImage = m0->mat;
+    // Arg 0 is the image
+    Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+    cv::Mat inputImage = m0->mat;
 
-        // Arg 1 is the camera matrix
-        Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
-        cv::Mat K = m1->mat;
+    // Arg 1 is the camera matrix
+    Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
+    cv::Mat K = m1->mat;
 
-        // Arg 2 is the distortion coefficents
-        Matrix* m2 = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
-        cv::Mat dist = m2->mat;
+    // Arg 2 is the distortion coefficents
+    Matrix* m2 = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
+    cv::Mat dist = m2->mat;
 
-        // Make an mat to hold the result image
-        cv::Mat outputImage;
+    // Make an mat to hold the result image
+    cv::Mat outputImage;
 
-        // Undistort
-        cv::undistort(inputImage, outputImage, K, dist);
+    // Undistort
+    cv::undistort(inputImage, outputImage, K, dist);
 
-        // Wrap the output image
-        Local<Object> outMatrixWrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-        Matrix *outMatrix = ObjectWrap::Unwrap<Matrix>(outMatrixWrap);
-        outMatrix->mat = outputImage;
+    // Wrap the output image
+    Local<Object> outMatrixWrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+    Matrix *outMatrix = ObjectWrap::Unwrap<Matrix>(outMatrixWrap);
+    outMatrix->mat = outputImage;
 
-        // Return the output image
-        NanReturnValue(outMatrixWrap);
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
+    // Return the output image
+    NanReturnValue(outMatrixWrap);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }
 
 // cv::initUndistortRectifyMap
-NAN_METHOD(ImgProc::InitUndistortRectifyMap)
-{
-    NanEscapableScope();
+NAN_METHOD(ImgProc::InitUndistortRectifyMap) {
+  NanEscapableScope();
 
-    try {
+  try {
+    // Arg 0 is the camera matrix
+    Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+    cv::Mat K = m0->mat;
 
-        // Arg 0 is the camera matrix
-        Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-        cv::Mat K = m0->mat;
+    // Arg 1 is the distortion coefficents
+    Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
+    cv::Mat dist = m1->mat;
 
-        // Arg 1 is the distortion coefficents
-        Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
-        cv::Mat dist = m1->mat;
+    // Arg 2 is the recification transformation
+    Matrix* m2 = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
+    cv::Mat R = m2->mat;
 
-        // Arg 2 is the recification transformation
-        Matrix* m2 = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
-        cv::Mat R = m2->mat;
+    // Arg 3 is the new camera matrix
+    Matrix* m3 = ObjectWrap::Unwrap<Matrix>(args[3]->ToObject());
+    cv::Mat newK = m3->mat;
 
-        // Arg 3 is the new camera matrix
-        Matrix* m3 = ObjectWrap::Unwrap<Matrix>(args[3]->ToObject());
-        cv::Mat newK = m3->mat;
-
-        // Arg 4 is the image size
-        cv::Size imageSize;
-        if (args[4]->IsArray()) {
-            Local<Object> v8sz = args[4]->ToObject();
-
-            imageSize = cv::Size(v8sz->Get(1)->IntegerValue(), v8sz->Get(0)->IntegerValue());
-        } else {
-            JSTHROW_TYPE("Must pass image size");
-        }
-
-        // Arg 5 is the first map type, skip for now
-        int m1type = args[5]->IntegerValue();
-
-        // Make matrices to hold the output maps
-        cv::Mat map1, map2;
-
-        // Compute the rectification map
-        cv::initUndistortRectifyMap(K, dist, R, newK, imageSize, m1type, map1, map2);
-
-        // Wrap the output maps
-        Local<Object> map1Wrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-        Matrix *map1Matrix = ObjectWrap::Unwrap<Matrix>(map1Wrap);
-        map1Matrix->mat = map1;
-
-        Local<Object> map2Wrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-        Matrix *map2Matrix = ObjectWrap::Unwrap<Matrix>(map2Wrap);
-        map2Matrix->mat = map2;
-
-        // Make a return object with the two maps
-        Local<Object> ret = NanNew<Object>();
-        ret->Set(NanNew<String>("map1"), map1Wrap);
-        ret->Set(NanNew<String>("map2"), map2Wrap);
-
-        // Return the maps
-        NanReturnValue(ret);
-
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
+    // Arg 4 is the image size
+    cv::Size imageSize;
+    if (args[4]->IsArray()) {
+      Local<Object> v8sz = args[4]->ToObject();
+      imageSize = cv::Size(v8sz->Get(1)->IntegerValue(), v8sz->Get(0)->IntegerValue());
+    } else {
+      JSTHROW_TYPE("Must pass image size");
     }
+
+    // Arg 5 is the first map type, skip for now
+    int m1type = args[5]->IntegerValue();
+
+    // Make matrices to hold the output maps
+    cv::Mat map1, map2;
+
+    // Compute the rectification map
+    cv::initUndistortRectifyMap(K, dist, R, newK, imageSize, m1type, map1, map2);
+
+    // Wrap the output maps
+    Local<Object> map1Wrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+    Matrix *map1Matrix = ObjectWrap::Unwrap<Matrix>(map1Wrap);
+    map1Matrix->mat = map1;
+
+    Local<Object> map2Wrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+    Matrix *map2Matrix = ObjectWrap::Unwrap<Matrix>(map2Wrap);
+    map2Matrix->mat = map2;
+
+    // Make a return object with the two maps
+    Local<Object> ret = NanNew<Object>();
+    ret->Set(NanNew<String>("map1"), map1Wrap);
+    ret->Set(NanNew<String>("map2"), map2Wrap);
+
+    // Return the maps
+    NanReturnValue(ret);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }
 
 // cv::remap
-NAN_METHOD(ImgProc::Remap)
-{
-    NanEscapableScope();
+NAN_METHOD(ImgProc::Remap) {
+  NanEscapableScope();
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg 0 is the image
-        Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-        cv::Mat inputImage = m0->mat;
+    // Arg 0 is the image
+    Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+    cv::Mat inputImage = m0->mat;
 
-        // Arg 1 is the first map
-        Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
-        cv::Mat map1 = m1->mat;
+    // Arg 1 is the first map
+    Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
+    cv::Mat map1 = m1->mat;
 
-        // Arg 2 is the second map
-        Matrix* m2 = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
-        cv::Mat map2 = m2->mat;
+    // Arg 2 is the second map
+    Matrix* m2 = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
+    cv::Mat map2 = m2->mat;
 
-        // Arg 3 is the interpolation mode
-        int interpolation = args[3]->IntegerValue();
+    // Arg 3 is the interpolation mode
+    int interpolation = args[3]->IntegerValue();
 
-        // Args 4, 5 border settings, skipping for now
+    // Args 4, 5 border settings, skipping for now
 
-        // Output image
-        cv::Mat outputImage;
+    // Output image
+    cv::Mat outputImage;
 
-        // Remap
-        cv::remap(inputImage, outputImage, map1, map2, interpolation);
+    // Remap
+    cv::remap(inputImage, outputImage, map1, map2, interpolation);
 
-        // Wrap the output image
-        Local<Object> outMatrixWrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-        Matrix *outMatrix = ObjectWrap::Unwrap<Matrix>(outMatrixWrap);
-        outMatrix->mat = outputImage;
+    // Wrap the output image
+    Local<Object> outMatrixWrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+    Matrix *outMatrix = ObjectWrap::Unwrap<Matrix>(outMatrixWrap);
+    outMatrix->mat = outputImage;
 
-        // Return the image
-        NanReturnValue(outMatrixWrap);
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
+    // Return the image
+    NanReturnValue(outMatrixWrap);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
 }

--- a/src/ImgProc.h
+++ b/src/ImgProc.h
@@ -3,17 +3,15 @@
 
 #include "OpenCV.h"
 
-// Implementation of imgproc.hpp functions
-
+/**
+ * Implementation of imgproc.hpp functions
+ */
 class ImgProc: public node::ObjectWrap {
 public:
-    static void Init(Handle<Object> target);
-
-    static NAN_METHOD(Undistort);
-
-    static NAN_METHOD(InitUndistortRectifyMap);
-
-    static NAN_METHOD(Remap);
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(Undistort);
+  static NAN_METHOD(InitUndistortRectifyMap);
+  static NAN_METHOD(Remap);
 };
 
 #endif

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -9,89 +9,88 @@ cv::Scalar setColor(Local<Object> objColor);
 cv::Point setPoint(Local<Object> objPoint);
 cv::Rect* setRect(Local<Object> objRect, cv::Rect &result);
 
-void
-Matrix::Init(Handle<Object> target) {
-	NanScope();
+void Matrix::Init(Handle<Object> target) {
+  NanScope();
 
-	//Class
+  //Class
   Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(Matrix::New);
   NanAssignPersistent(constructor, ctor);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
   ctor->SetClassName(NanNew("Matrix"));
 
   // Prototype
-	NODE_SET_PROTOTYPE_METHOD(ctor, "row", Row);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "col", Col);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "pixelRow", PixelRow);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "pixelCol", PixelCol);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "empty", Empty);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "get", Get);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "set", Set);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "put", Put);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "brightness", Brightness);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "normalize", Normalize);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "getData", GetData);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "pixel", Pixel);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "width", Width);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "height", Height);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "size", Size);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "clone", Clone);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "crop", Crop);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "toBuffer", ToBuffer);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "toBufferAsync", ToBufferAsync);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "ellipse", Ellipse);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "rectangle", Rectangle);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "line", Line);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "fillPoly", FillPoly);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "save", Save);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "saveAsync", SaveAsync);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "resize", Resize);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "rotate", Rotate);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "copyTo", CopyTo);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "pyrDown", PyrDown);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "pyrUp", PyrUp);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "channels", Channels);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "convertGrayscale", ConvertGrayscale);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "convertHSVscale", ConvertHSVscale);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "gaussianBlur", GaussianBlur);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "row", Row);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "col", Col);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "pixelRow", PixelRow);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "pixelCol", PixelCol);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "empty", Empty);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "get", Get);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "set", Set);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "put", Put);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "brightness", Brightness);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "normalize", Normalize);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "getData", GetData);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "pixel", Pixel);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "width", Width);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "height", Height);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "size", Size);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "clone", Clone);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "crop", Crop);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "toBuffer", ToBuffer);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "toBufferAsync", ToBufferAsync);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "ellipse", Ellipse);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "rectangle", Rectangle);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "line", Line);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "fillPoly", FillPoly);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "save", Save);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "saveAsync", SaveAsync);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "resize", Resize);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "rotate", Rotate);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "copyTo", CopyTo);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "pyrDown", PyrDown);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "pyrUp", PyrUp);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "channels", Channels);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "convertGrayscale", ConvertGrayscale);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "convertHSVscale", ConvertHSVscale);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "gaussianBlur", GaussianBlur);
   NODE_SET_PROTOTYPE_METHOD(ctor, "medianBlur", MedianBlur);
   NODE_SET_PROTOTYPE_METHOD(ctor, "bilateralFilter", BilateralFilter);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "copy", Copy);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "flip", Flip);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "roi", ROI);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "ptr", Ptr);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "absDiff", AbsDiff);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "addWeighted", AddWeighted);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "bitwiseXor", BitwiseXor);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "bitwiseNot", BitwiseNot);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "copy", Copy);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "flip", Flip);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "roi", ROI);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "ptr", Ptr);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "absDiff", AbsDiff);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "addWeighted", AddWeighted);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "bitwiseXor", BitwiseXor);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "bitwiseNot", BitwiseNot);
   NODE_SET_PROTOTYPE_METHOD(ctor, "bitwiseAnd", BitwiseAnd);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "countNonZero", CountNonZero);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "canny", Canny);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "dilate", Dilate);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "erode", Erode);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "findContours", FindContours);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "drawContour", DrawContour);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "drawAllContours", DrawAllContours);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "goodFeaturesToTrack", GoodFeaturesToTrack);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "houghLinesP", HoughLinesP);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "crop", Crop);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "houghCircles", HoughCircles);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "inRange", inRange);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "adjustROI", AdjustROI);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "locateROI", LocateROI);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "threshold", Threshold);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "adaptiveThreshold", AdaptiveThreshold);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "meanStdDev", MeanStdDev);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "cvtColor", CvtColor);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "split", Split);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "merge", Merge);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "equalizeHist", EqualizeHist);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "floodFill", FloodFill);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "matchTemplate", MatchTemplate);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "countNonZero", CountNonZero);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "canny", Canny);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "dilate", Dilate);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "erode", Erode);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "findContours", FindContours);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "drawContour", DrawContour);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "drawAllContours", DrawAllContours);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "goodFeaturesToTrack", GoodFeaturesToTrack);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "houghLinesP", HoughLinesP);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "crop", Crop);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "houghCircles", HoughCircles);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "inRange", inRange);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "adjustROI", AdjustROI);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "locateROI", LocateROI);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "threshold", Threshold);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "adaptiveThreshold", AdaptiveThreshold);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "meanStdDev", MeanStdDev);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "cvtColor", CvtColor);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "split", Split);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "merge", Merge);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "equalizeHist", EqualizeHist);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "floodFill", FloodFill);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "matchTemplate", MatchTemplate);
   NODE_SET_PROTOTYPE_METHOD(ctor, "templateMatches", TemplateMatches);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "minMaxLoc", MinMaxLoc);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "pushBack", PushBack);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "putText", PutText);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "minMaxLoc", MinMaxLoc);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "pushBack", PushBack);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "putText", PutText);
   NODE_SET_PROTOTYPE_METHOD(ctor, "getPerspectiveTransform", GetPerspectiveTransform);
   NODE_SET_PROTOTYPE_METHOD(ctor, "warpPerspective", WarpPerspective);
   NODE_SET_METHOD(ctor, "Zeros", Zeros);
@@ -118,12 +117,12 @@ NAN_METHOD(Matrix::New) {
     mat = new Matrix;
   } else if (args.Length() == 2 && args[0]->IsInt32() && args[1]->IsInt32()) {
     mat = new Matrix(args[0]->IntegerValue(), args[1]->IntegerValue());
-  } else if (args.Length() == 3 && args[0]->IsInt32() && args[1]->IsInt32() && args[2]->IsInt32()) {
-    mat = new Matrix(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue());
+  } else if (args.Length() == 3 && args[0]->IsInt32() && args[1]->IsInt32()
+      && args[2]->IsInt32()) {
+    mat = new Matrix(args[0]->IntegerValue(), args[1]->IntegerValue(),
+        args[2]->IntegerValue());
   } else if (args.Length() == 4 && args[0]->IsInt32() && args[1]->IsInt32() &&
         args[2]->IsInt32() && args[3]->IsArray()) {
-    mat = new Matrix(args[0]->IntegerValue(), args[1]->IntegerValue(),
-        args[2]->IntegerValue(), args[3]->ToObject());
   } else {  // if (args.Length() == 5) {
     Matrix *other = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
     int x = args[1]->IntegerValue();
@@ -137,22 +136,24 @@ NAN_METHOD(Matrix::New) {
   NanReturnValue(args.Holder());
 }
 
-
-Matrix::Matrix(): ObjectWrap() {
-	mat = cv::Mat();
+Matrix::Matrix() :
+    ObjectWrap() {
+  mat = cv::Mat();
 }
 
-
-Matrix::Matrix(int rows, int cols): ObjectWrap() {
-    mat = cv::Mat(rows, cols, CV_32FC3);
+Matrix::Matrix(int rows, int cols) :
+    ObjectWrap() {
+  mat = cv::Mat(rows, cols, CV_32FC3);
 }
 
-Matrix::Matrix(int rows, int cols, int type): ObjectWrap() {
-    mat = cv::Mat(rows, cols, type);
+Matrix::Matrix(int rows, int cols, int type) :
+    ObjectWrap() {
+  mat = cv::Mat(rows, cols, type);
 }
 
-Matrix::Matrix(cv::Mat m, cv::Rect roi): ObjectWrap() {
-	mat = cv::Mat(m, roi);
+Matrix::Matrix(cv::Mat m, cv::Rect roi) :
+    ObjectWrap() {
+  mat = cv::Mat(m, roi);
 }
 
 Matrix::Matrix(int rows, int cols, int type, Local<Object> scalarObj) {
@@ -171,21 +172,18 @@ Matrix::Matrix(int rows, int cols, int type, Local<Object> scalarObj) {
   }
 }
 
-
-
-NAN_METHOD(Matrix::Empty){
-	SETUP_FUNCTION(Matrix)
+NAN_METHOD(Matrix::Empty) {
+  SETUP_FUNCTION(Matrix)
   NanReturnValue(NanNew<Boolean>(self->mat.empty()));
 }
 
-double
-Matrix::DblGet(cv::Mat mat, int i, int j){
+double Matrix::DblGet(cv::Mat mat, int i, int j) {
 
   double val = 0;
   cv::Vec3b pix;
   unsigned int pint = 0;
 
-  switch(mat.type()){
+  switch (mat.type()) {
     case CV_32FC3:
       pix = mat.at<cv::Vec3b>(i, j);
       pint |= (uchar) pix.val[2];
@@ -193,269 +191,246 @@ Matrix::DblGet(cv::Mat mat, int i, int j){
       pint |= ((uchar) pix.val[0]) << 16;
       val = (double) pint;
       break;
-
     case CV_64FC1:
       val = mat.at<double>(i, j);
       break;
-
     default:
-	    val = mat.at<double>(i,j);
+      val = mat.at<double>(i, j);
       break;
   }
 
   return val;
 }
 
+NAN_METHOD(Matrix::Pixel) {
+  SETUP_FUNCTION(Matrix)
 
-NAN_METHOD(Matrix::Pixel){
-	SETUP_FUNCTION(Matrix)
+  int y = args[0]->IntegerValue();
+  int x = args[1]->IntegerValue();
 
-	int y = args[0]->IntegerValue();
-	int x = args[1]->IntegerValue();
+  // cv::Scalar scal = self->mat.at<uchar>(y, x);
 
-	//cv::Scalar scal = self->mat.at<uchar>(y, x);
+  if (args.Length() == 3) {
+    Local < Object > objColor = args[2]->ToObject();
 
+    if (self->mat.channels() == 3) {
+      self->mat.at<cv::Vec3b>(y, x)[0] =
+          (uchar) objColor->Get(0)->IntegerValue();
+      self->mat.at<cv::Vec3b>(y, x)[1] =
+          (uchar) objColor->Get(1)->IntegerValue();
+      self->mat.at<cv::Vec3b>(y, x)[2] =
+          (uchar) objColor->Get(2)->IntegerValue();
+    } else if (self->mat.channels() == 1)
+      self->mat.at<uchar>(y, x) = (uchar) objColor->Get(0)->IntegerValue();
 
-	if(args.Length() == 3){
-
-		Local<Object> objColor = args[2]->ToObject();
-
-		if(self->mat.channels() == 3){
-			self->mat.at<cv::Vec3b>(y, x)[0] =  (uchar) objColor->Get(0)->IntegerValue();
-			self->mat.at<cv::Vec3b>(y, x)[1] =  (uchar) objColor->Get(1)->IntegerValue();
-			self->mat.at<cv::Vec3b>(y, x)[2] =  (uchar) objColor->Get(2)->IntegerValue();
-		}
-		else if(self->mat.channels() == 1)
-			self->mat.at<uchar>(y,x) = (uchar) objColor->Get(0)->IntegerValue();
-
-    NanReturnValue( args[2]->ToObject() );
-	}else{
-
-		if(self->mat.channels() == 3){
-			cv::Vec3b intensity = self->mat.at<cv::Vec3b>(y, x);
-
-			v8::Local<v8::Array> arr = NanNew<v8::Array>(3);
-			arr->Set(0, NanNew<Number>( intensity[0] ));
-			arr->Set(1, NanNew<Number>( intensity[1] ));
-			arr->Set(2, NanNew<Number>( intensity[2] ));
-			NanReturnValue(arr);
-		}
-		else if(self->mat.channels() == 1){
-
-			uchar intensity = self->mat.at<uchar>(y, x);
-			NanReturnValue(NanNew<Number>(intensity));
-		}
-	}
-  NanReturnUndefined();
-	//double val = Matrix::DblGet(t, i, j);
-	//NanReturnValue(NanNew<Number>(val));
-}
-
-NAN_METHOD(Matrix::Get){
-	SETUP_FUNCTION(Matrix)
-
-	int i = args[0]->IntegerValue();
-	int j = args[1]->IntegerValue();
-
-  double val = Matrix::DblGet(self->mat, i, j);
-  NanReturnValue( NanNew<Number>(val) );
-}
-
-
-NAN_METHOD(Matrix::Set){
-	SETUP_FUNCTION(Matrix)
-
-	int i = args[0]->IntegerValue();
-	int j = args[1]->IntegerValue();
-	double val = args[2]->NumberValue();
-  int vint = 0;
-
-	if(args.Length() == 4) {
-		self->mat.at<cv::Vec3b>(i,j)[args[3]->NumberValue()] = val;
-
-	} else if(args.Length() == 3) {
-    switch(self->mat.type()){
-
-      case CV_32FC3:
-        vint = static_cast<unsigned int>(val + 0.5);
-		    self->mat.at<cv::Vec3b>(i,j)[0] = (uchar) (vint >> 16) & 0xff;
-		    self->mat.at<cv::Vec3b>(i,j)[1] = (uchar) (vint >> 8) & 0xff;
-		    self->mat.at<cv::Vec3b>(i,j)[2] = (uchar) (vint) & 0xff;
-        //printf("!!!i %x, %x, %x", (vint >> 16) & 0xff, (vint >> 8) & 0xff, (vint) & 0xff);
-
-        break;
-
-      default:
-        self->mat.at<double>(i,j) = val;
-    }
-
-
+    NanReturnValue(args[2]->ToObject());
   } else {
-      NanThrowTypeError( "Invalid number of arguments" );
+    if (self->mat.channels() == 3) {
+      cv::Vec3b intensity = self->mat.at<cv::Vec3b>(y, x);
+
+      v8::Local < v8::Array > arr = NanNew<v8::Array>(3);
+      arr->Set(0, NanNew<Number>(intensity[0]));
+      arr->Set(1, NanNew<Number>(intensity[1]));
+      arr->Set(2, NanNew<Number>(intensity[2]));
+      NanReturnValue(arr);
+    } else if (self->mat.channels() == 1) {
+      uchar intensity = self->mat.at<uchar>(y, x);
+      NanReturnValue(NanNew<Number>(intensity));
+    }
   }
 
-	NanReturnUndefined();
+  NanReturnUndefined();
+  // double val = Matrix::DblGet(t, i, j);
+  // NanReturnValue(NanNew<Number>(val));
+}
+
+NAN_METHOD(Matrix::Get) {
+  SETUP_FUNCTION(Matrix)
+
+  int i = args[0]->IntegerValue();
+  int j = args[1]->IntegerValue();
+
+  double val = Matrix::DblGet(self->mat, i, j);
+  NanReturnValue(NanNew<Number>(val));
+}
+
+NAN_METHOD(Matrix::Set) {
+  SETUP_FUNCTION(Matrix)
+
+  int i = args[0]->IntegerValue();
+  int j = args[1]->IntegerValue();
+  double val = args[2]->NumberValue();
+  int vint = 0;
+
+  if (args.Length() == 4) {
+    self->mat.at<cv::Vec3b>(i, j)[args[3]->NumberValue()] = val;
+  } else if (args.Length() == 3) {
+    switch (self->mat.type()) {
+      case CV_32FC3:
+        vint = static_cast<unsigned int>(val + 0.5);
+        self->mat.at<cv::Vec3b>(i, j)[0] = (uchar) (vint >> 16) & 0xff;
+        self->mat.at<cv::Vec3b>(i, j)[1] = (uchar) (vint >> 8) & 0xff;
+        self->mat.at<cv::Vec3b>(i, j)[2] = (uchar) (vint) & 0xff;
+        // printf("!!!i %x, %x, %x", (vint >> 16) & 0xff, (vint >> 8) & 0xff, (vint) & 0xff);
+        break;
+      default:
+        self->mat.at<double>(i, j) = val;
+    }
+
+  } else {
+    NanThrowTypeError("Invalid number of arguments");
+  }
+
+  NanReturnUndefined();
 }
 
 // @author tualo
 // put node buffer directly into the image data
 // img.put(new Buffer([0,100,0,100,100...]));
-NAN_METHOD(Matrix::Put){
-	SETUP_FUNCTION(Matrix)
+NAN_METHOD(Matrix::Put) {
+  SETUP_FUNCTION(Matrix)
 
-	if (!Buffer::HasInstance(args[0])) {
-		NanThrowTypeError( "Not a buffer" );
-	}
-	const char* buffer_data = Buffer::Data(args[0]);
-	size_t buffer_length = Buffer::Length(args[0]);
-	memcpy(self->mat.data, buffer_data, buffer_length);
-	NanReturnUndefined();
+  if (!Buffer::HasInstance(args[0])) {
+    NanThrowTypeError("Not a buffer");
+  }
+  const char* buffer_data = Buffer::Data(args[0]);
+  size_t buffer_length = Buffer::Length(args[0]);
+  memcpy(self->mat.data, buffer_data, buffer_length);
+  NanReturnUndefined();
 }
-
 
 // @author tualo
 // getData getting node buffer of image data
 NAN_METHOD(Matrix::GetData) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-	int size = self->mat.rows * self->mat.cols * self->mat.elemSize1();
-	Local<Object> buf = NanNewBufferHandle(size);
-	uchar* data = (uchar*) Buffer::Data(buf);
-	memcpy(data, self->mat.data, size);
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  int size = self->mat.rows * self->mat.cols * self->mat.elemSize1();
+  Local<Object> buf = NanNewBufferHandle(size);
+  uchar* data = (uchar*) Buffer::Data(buf);
+  memcpy(data, self->mat.data, size);
 
-	v8::Local<v8::Object> globalObj = NanGetCurrentContext()->Global();
-	v8::Local<v8::Function> bufferConstructor = v8::Local<v8::Function>::Cast(globalObj->Get(NanNew<String>("Buffer")));
-	v8::Handle<v8::Value> constructorArgs[3] = {buf, NanNew<v8::Integer>((unsigned) size), NanNew<v8::Integer>(0)};
-	v8::Local<v8::Object> actualBuffer = bufferConstructor->NewInstance(3, constructorArgs);
+  v8::Local<v8::Object> globalObj = NanGetCurrentContext()->Global();
+  v8::Local<v8::Function> bufferConstructor = v8::Local<v8::Function>::Cast(globalObj->Get(NanNew<String>("Buffer")));
+  v8::Handle<v8::Value> constructorArgs[3] = {buf, NanNew<v8::Integer>((unsigned) size), NanNew<v8::Integer>(0)};
+  v8::Local<v8::Object> actualBuffer = bufferConstructor->NewInstance(3, constructorArgs);
 
-	NanReturnValue(actualBuffer);
-
+  NanReturnValue(actualBuffer);
 }
 
-NAN_METHOD(Matrix::Brightness){
-	NanScope();
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+NAN_METHOD(Matrix::Brightness) {
+  NanScope();
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
 
-	if (args.Length() == 2){
+  if (args.Length() == 2) {
+    cv::Mat image;
 
-		cv::Mat image;
+    if (self->mat.channels() == 3) {
+      image = self->mat;
+    } else if (self->mat.channels() == 1) {
+      cv::Mat myimg = self->mat;
+      cv::cvtColor(myimg, image, CV_GRAY2RGB);
+    } else {
+      NanThrowError("those channels are not supported");
+    }
 
-		if(self->mat.channels() == 3){
-			image = self->mat;
-		}else if(self->mat.channels() == 1){
-			cv::Mat myimg = self->mat;
-			cv::cvtColor(myimg, image, CV_GRAY2RGB);
-		}else{
-			NanThrowError("those channels are not supported");
-		}
+    cv::Mat new_image = cv::Mat::zeros( image.size(), image.type() );
+    double alpha = args[0]->NumberValue();
+    int beta = args[1]->IntegerValue();
 
+    // Do the operation new_image(i,j) = alpha*image(i,j) + beta
+    for (int y = 0; y < image.rows; y++ ) {
+      for (int x = 0; x < image.cols; x++ ) {
+        for (int c = 0; c < 3; c++ ) {
+          new_image.at<cv::Vec3b>(y,x)[c] =
+              cv::saturate_cast<uchar>(alpha*( image.at<cv::Vec3b>(y,x)[c] ) + beta);
+        }
+      }
+    }
 
-		cv::Mat new_image = cv::Mat::zeros( image.size(), image.type() );
-		double alpha = args[0]->NumberValue();
-		int beta = args[1]->IntegerValue();
-		/// Do the operation new_image(i,j) = alpha*image(i,j) + beta
-		for( int y = 0; y < image.rows; y++ ){
-			for( int x = 0; x < image.cols; x++ ){
-				for( int c = 0; c < 3; c++ ){
-					new_image.at<cv::Vec3b>(y,x)[c] = cv::saturate_cast<uchar>( alpha*( image.at<cv::Vec3b>(y,x)[c] ) + beta );
-				}
-			}
-		}
+    if (self->mat.channels() == 3) {
+      new_image.copyTo(self->mat);
+    } else if (self->mat.channels() == 1) {
+      cv::Mat gray;
+      cv::cvtColor(new_image, gray, CV_BGR2GRAY);
+      gray.copyTo(self->mat);
+    }
+  } else {
+    if (args.Length() == 1) {
+      int diff = args[0]->IntegerValue();
+      cv::Mat img = self->mat + diff;
+      img.copyTo(self->mat);
+    } else {
+      NanReturnValue(NanNew("Insufficient or wrong arguments"));
+    }
+  }
 
-		if(self->mat.channels() == 3){
-			new_image.copyTo(self->mat);
-		}else if(self->mat.channels() == 1){
-			cv::Mat gray;
-			cv::cvtColor(new_image, gray, CV_BGR2GRAY);
-			gray.copyTo(self->mat);
-		}
-
-	}else{
-		if (args.Length() == 1){
-			int diff = args[0]->IntegerValue();
-			cv::Mat img = self->mat + diff;
-			img.copyTo(self->mat);
-		}else{
-			NanReturnValue(NanNew("Insufficient or wrong arguments"));
-		}
-	}
-
-
-	NanReturnNull();
+  NanReturnNull();
 }
 
 // @author tualo
 // normalize wrapper
 NAN_METHOD(Matrix::Normalize) {
-
-
-	if (!args[0]->IsNumber())
+  if (!args[0]->IsNumber()) {
     NanThrowTypeError("min is required (argument 1)");
+  }
 
-	if (!args[1]->IsNumber())
+  if (!args[1]->IsNumber()) {
     NanThrowTypeError("max is required (argument 2)");
+  }
 
-	int type = cv::NORM_MINMAX;
-	if (args[2]->IsNumber()){
-		type = args[2]->Uint32Value();
-		if (
-			(type!=cv::NORM_MINMAX) ||
-			(type!=cv::NORM_INF) ||
-			(type!=cv::NORM_L1) ||
-			(type!=cv::NORM_L2) ||
-			(type!=cv::NORM_L2SQR) ||
-			(type!=cv::NORM_HAMMING) ||
-			(type!=cv::NORM_HAMMING2) ||
-			(type!=cv::NORM_RELATIVE) ||
-			(type!=cv::NORM_TYPE_MASK)
-		){
-			NanThrowTypeError("type value must be NORM_INF=1, NORM_L1=2, NORM_L2=4, NORM_L2SQR=5, NORM_HAMMING=6, NORM_HAMMING2=7, NORM_TYPE_MASK=7, NORM_RELATIVE=8, NORM_MINMAX=32 ");
-		}
-	}
-	int dtype = -1;
-	if (args[3]->IsNumber()){
-		dtype = args[3]->IntegerValue();
-	}
+  int type = cv::NORM_MINMAX;
+  if (args[2]->IsNumber()) {
+    type = args[2]->Uint32Value();
+    if ((type != cv::NORM_MINMAX) || (type != cv::NORM_INF)
+        || (type != cv::NORM_L1) || (type != cv::NORM_L2)
+        || (type != cv::NORM_L2SQR) || (type != cv::NORM_HAMMING)
+        || (type != cv::NORM_HAMMING2) || (type != cv::NORM_RELATIVE)
+        || (type != cv::NORM_TYPE_MASK)) {
+      NanThrowTypeError("type value must be NORM_INF=1, NORM_L1=2, NORM_L2=4,"
+          " NORM_L2SQR=5, NORM_HAMMING=6, NORM_HAMMING2=7, NORM_TYPE_MASK=7, "
+          "NORM_RELATIVE=8, NORM_MINMAX=32 ");
+    }
+  }
+  int dtype = -1;
+  if (args[3]->IsNumber()) {
+    dtype = args[3]->IntegerValue();
+  }
 
-	double min = args[0]->NumberValue();
-	double max = args[1]->NumberValue();
+  double min = args[0]->NumberValue();
+  double max = args[1]->NumberValue();
 
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  cv::Mat norm;
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-	cv::Mat norm;
+  cv::Mat mask;
+  if (args[4]->IsObject()) {
+    Matrix *mmask = ObjectWrap::Unwrap<Matrix>(args[4]->ToObject());
+    mask = mmask->mat;
+  }
 
-	cv::Mat mask;
-	if (args[4]->IsObject()){
-		Matrix *mmask = ObjectWrap::Unwrap<Matrix>( args[4]->ToObject() );
-		mask = mmask->mat;
-	}
+  cv::normalize(self->mat, norm, min, max, type, dtype, mask);
 
+  norm.copyTo(self->mat);
 
-	cv::normalize(self->mat, norm,min,max, type, dtype, mask);
-
-	norm.copyTo(self->mat);
-
-	NanReturnNull();
+  NanReturnNull();
 }
 
+NAN_METHOD(Matrix::Size) {
+  SETUP_FUNCTION(Matrix)
 
+  v8::Local < v8::Array > arr = NanNew<Array>(2);
+  arr->Set(0, NanNew<Number>(self->mat.size().height));
+  arr->Set(1, NanNew<Number>(self->mat.size().width));
 
-NAN_METHOD(Matrix::Size){
-	SETUP_FUNCTION(Matrix)
-
-	v8::Local<v8::Array> arr = NanNew<Array>(2);
-	arr->Set(0, NanNew<Number>(self->mat.size().height));
-	arr->Set(1, NanNew<Number>(self->mat.size().width));
-
-	NanReturnValue(arr);
+  NanReturnValue(arr);
 }
 
+NAN_METHOD(Matrix::Clone) {
+  SETUP_FUNCTION(Matrix)
 
-NAN_METHOD(Matrix::Clone){
-	SETUP_FUNCTION(Matrix)
-
-  Local<Object> im_h = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+  Local < Object > im_h =
+      NanNew(Matrix::constructor)->GetFunction()->NewInstance();
 
   Matrix *m = ObjectWrap::Unwrap<Matrix>(im_h);
   m->mat = self->mat.clone();
@@ -463,209 +438,211 @@ NAN_METHOD(Matrix::Clone){
   NanReturnValue(im_h);
 }
 
-NAN_METHOD(Matrix::Crop){
+NAN_METHOD(Matrix::Crop) {
+  SETUP_FUNCTION(Matrix)
 
-	SETUP_FUNCTION(Matrix)
+  if ((args.Length() == 4) && (args[0]->IsNumber()) && (args[1]->IsNumber())
+      && (args[2]->IsNumber()) && (args[3]->IsNumber())) {
 
-  	if ((args.Length() == 4) && (args[0]->IsNumber()) && (args[1]->IsNumber()) && (args[2]->IsNumber()) && (args[3]->IsNumber())){
+    int x = args[0]->IntegerValue();
+    int y = args[1]->IntegerValue();
+    int width = args[2]->IntegerValue();
+    int height = args[3]->IntegerValue();
 
-  		int x = args[0]->IntegerValue();
-  		int y = args[1]->IntegerValue();
-  		int width = args[2]->IntegerValue();
-  		int height = args[3]->IntegerValue();
+    cv::Rect roi(x, y, width, height);
 
-		cv::Rect roi(x, y, width, height);
+    Local < Object > im_h =
+        NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+    Matrix *m = ObjectWrap::Unwrap<Matrix>(im_h);
+    m->mat = self->mat(roi);
 
-    Local<Object> im_h = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-		Matrix *m = ObjectWrap::Unwrap<Matrix>(im_h);
-		m->mat = self->mat(roi);
-
-		NanReturnValue(im_h);
-	}
-	else{
-		NanReturnValue(NanNew("Insufficient or wrong arguments"));
-	}
+    NanReturnValue(im_h);
+  } else {
+    NanReturnValue(NanNew("Insufficient or wrong arguments"));
+  }
 }
 
-NAN_METHOD(Matrix::Row){
-	SETUP_FUNCTION(Matrix)
+NAN_METHOD(Matrix::Row) {
+  SETUP_FUNCTION(Matrix)
 
-	int width = self->mat.size().width;
-	int y = args[0]->IntegerValue();
-	v8::Local<v8::Array> arr = NanNew<Array>(width);
+  int width = self->mat.size().width;
+  int y = args[0]->IntegerValue();
+  v8::Local < v8::Array > arr = NanNew<Array>(width);
 
-	for (int x=0; x<width; x++){
-		double v = Matrix::DblGet(self->mat, y, x);
-		arr->Set(x, NanNew<Number>(v));
-	}
-
-	NanReturnValue(arr);
-}
-
-
-NAN_METHOD(Matrix::PixelRow){
-	SETUP_FUNCTION(Matrix)
-
-	int width = self->mat.size().width;
-	int y = args[0]->IntegerValue();
-	v8::Local<v8::Array> arr = NanNew<Array>(width * 3);
-
-	for (int x=0; x<width; x++){
-		cv::Vec3b pixel = self->mat.at<cv::Vec3b>(y, x);
-		int offset = x * 3;
-		arr->Set(offset    , NanNew<Number>((double)pixel.val[0]));
-		arr->Set(offset + 1, NanNew<Number>((double)pixel.val[1]));
-		arr->Set(offset + 2, NanNew<Number>((double)pixel.val[2]));
+  for (int x = 0; x < width; x++) {
+    double v = Matrix::DblGet(self->mat, y, x);
+    arr->Set(x, NanNew<Number>(v));
   }
 
-	NanReturnValue(arr);
+  NanReturnValue(arr);
 }
 
+NAN_METHOD(Matrix::PixelRow) {
+  SETUP_FUNCTION(Matrix)
 
-NAN_METHOD(Matrix::Col){
+  int width = self->mat.size().width;
+  int y = args[0]->IntegerValue();
+  v8::Local < v8::Array > arr = NanNew<Array>(width * 3);
+
+  for (int x = 0; x < width; x++) {
+    cv::Vec3b pixel = self->mat.at<cv::Vec3b>(y, x);
+    int offset = x * 3;
+    arr->Set(offset, NanNew<Number>((double) pixel.val[0]));
+    arr->Set(offset + 1, NanNew<Number>((double) pixel.val[1]));
+    arr->Set(offset + 2, NanNew<Number>((double) pixel.val[2]));
+  }
+
+  NanReturnValue(arr);
+}
+
+NAN_METHOD(Matrix::Col) {
   SETUP_FUNCTION(Matrix)
 
   int height = self->mat.size().height;
   int x = args[0]->IntegerValue();
-  v8::Local<v8::Array> arr = NanNew<Array>(height);
+  v8::Local < v8::Array > arr = NanNew<Array>(height);
 
-  for (int y=0; y<height; y++){
+  for (int y = 0; y < height; y++) {
     double v = Matrix::DblGet(self->mat, y, x);
     arr->Set(y, NanNew<Number>(v));
   }
   NanReturnValue(arr);
 }
 
-
-NAN_METHOD(Matrix::PixelCol){
+NAN_METHOD(Matrix::PixelCol) {
   SETUP_FUNCTION(Matrix)
 
   int height = self->mat.size().height;
   int x = args[0]->IntegerValue();
-  v8::Local<v8::Array> arr = NanNew<Array>(height * 3);
+  v8::Local < v8::Array > arr = NanNew<Array>(height * 3);
 
-  for (int y=0; y<height; y++){
+  for (int y = 0; y < height; y++) {
     cv::Vec3b pixel = self->mat.at<cv::Vec3b>(y, x);
     int offset = y * 3;
-    arr->Set(offset    , NanNew<Number>((double)pixel.val[0]));
-    arr->Set(offset + 1, NanNew<Number>((double)pixel.val[1]));
-    arr->Set(offset + 2, NanNew<Number>((double)pixel.val[2]));
+    arr->Set(offset, NanNew<Number>((double) pixel.val[0]));
+    arr->Set(offset + 1, NanNew<Number>((double) pixel.val[1]));
+    arr->Set(offset + 2, NanNew<Number>((double) pixel.val[2]));
   }
   NanReturnValue(arr);
 }
 
+NAN_METHOD(Matrix::Width) {
+  SETUP_FUNCTION(Matrix)
 
-NAN_METHOD(Matrix::Width){
-	SETUP_FUNCTION(Matrix)
-
-	NanReturnValue(NanNew<Number>(self->mat.size().width));
+  NanReturnValue(NanNew<Number>(self->mat.size().width));
 }
 
-NAN_METHOD(Matrix::Height){
-	SETUP_FUNCTION(Matrix)
+NAN_METHOD(Matrix::Height) {
+  SETUP_FUNCTION(Matrix)
 
-	NanReturnValue(NanNew<Number>(self->mat.size().height));
+  NanReturnValue(NanNew<Number>(self->mat.size().height));
 }
 
-NAN_METHOD(Matrix::Channels){
-	 SETUP_FUNCTION(Matrix)
+NAN_METHOD(Matrix::Channels) {
+  SETUP_FUNCTION(Matrix)
 
-	NanReturnValue(NanNew<Number>(self->mat.channels()));
+  NanReturnValue(NanNew<Number>(self->mat.channels()));
 }
 
+NAN_METHOD(Matrix::ToBuffer) {
+  SETUP_FUNCTION(Matrix)
 
-NAN_METHOD(Matrix::ToBuffer){
-	SETUP_FUNCTION(Matrix)
+  if ((args.Length() > 0) && (args[0]->IsFunction())) {
+    return Matrix::ToBufferAsync(args);
+  }
 
-    if ((args.Length() > 0) && (args[0]->IsFunction())) {
-        return Matrix::ToBufferAsync(args);
+  // SergeMv changes
+  // img.toBuffer({ext: ".png", pngCompression: 9}); // default png compression is 3
+  // img.toBuffer({ext: ".jpg", jpegQuality: 80});
+  // img.toBuffer(); // creates Jpeg with quality of 95 (Opencv default quality)
+  // via the ext you can do other image formats too (like tiff), see
+  // http://docs.opencv.org/modules/highgui/doc/reading_and_writing_images_and_video.html#imencode
+  //---------------------------
+  // Provide default value
+  const char *ext = ".jpg";
+  std::string optExt;
+  std::vector<int> params;
+
+  // See if the options argument is passed
+  if ((args.Length() > 0) && (args[0]->IsObject())) {
+    // Get this options argument
+    v8::Handle < v8::Object > options = v8::Handle<v8::Object>::Cast(args[0]);
+    // If the extension (image format) is provided
+    if (options->Has(NanNew<String>("ext"))) {
+      v8::String::Utf8Value str(
+          options->Get(NanNew<String>("ext"))->ToString());
+      optExt = *str;
+      ext = (const char *) optExt.c_str();
     }
-
-    // SergeMv changes
-    // img.toBuffer({ext: ".png", pngCompression: 9}); // default png compression is 3
-    // img.toBuffer({ext: ".jpg", jpegQuality: 80});
-    // img.toBuffer(); // creates Jpeg with quality of 95 (Opencv default quality)
-    // via the ext you can do other image formats too (like tiff), see
-    // http://docs.opencv.org/modules/highgui/doc/reading_and_writing_images_and_video.html#imencode
-    //---------------------------
-    // Provide default value
-    const char *ext = ".jpg";
-    std::string optExt;
-    std::vector<int> params;
-    // See if the options argument is passed
-    if ((args.Length() > 0) && (args[0]->IsObject())) {
-        // Get this options argument
-        v8::Handle<v8::Object> options = v8::Handle<v8::Object>::Cast(args[0]);
-        // If the extension (image format) is provided
-        if (options->Has(NanNew<String>("ext"))) {
-            v8::String::Utf8Value str ( options->Get(NanNew<String>("ext"))->ToString() );
-            optExt = *str;
-            ext = (const char *) optExt.c_str();
-        }
-        if (options->Has(NanNew<String>("jpegQuality"))) {
-            int compression = options->Get(NanNew<String>("jpegQuality"))->IntegerValue();
-            params.push_back(CV_IMWRITE_JPEG_QUALITY);
-            params.push_back(compression);
-        }
-        if (options->Has(NanNew<String>("pngCompression"))) {
-            int compression = options->Get(NanNew<String>("pngCompression"))->IntegerValue();
-            params.push_back(CV_IMWRITE_PNG_COMPRESSION);
-            params.push_back(compression);
-        }
+    if (options->Has(NanNew<String>("jpegQuality"))) {
+      int compression =
+          options->Get(NanNew<String>("jpegQuality"))->IntegerValue();
+      params.push_back(CV_IMWRITE_JPEG_QUALITY);
+      params.push_back(compression);
     }
-    //---------------------------
+    if (options->Has(NanNew<String>("pngCompression"))) {
+      int compression =
+          options->Get(NanNew<String>("pngCompression"))->IntegerValue();
+      params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+      params.push_back(compression);
+    }
+  }
 
-	std::vector<uchar> vec(0);
+  //---------------------------
+  std::vector<uchar> vec(0);
 
+  cv::imencode(ext, self->mat, vec, params);
 
-	cv::imencode(ext, self->mat, vec, params);
-
-  Local<Object> buf = NanNewBufferHandle(vec.size());
+  Local < Object > buf = NanNewBufferHandle(vec.size());
   uchar* data = (uchar*) Buffer::Data(buf);
   memcpy(data, &vec[0], vec.size());
 
-	v8::Local<v8::Object> globalObj = NanGetCurrentContext()->Global();
-	v8::Local<v8::Function> bufferConstructor = v8::Local<v8::Function>::Cast(globalObj->Get(NanNew<String>("Buffer")));
-	v8::Handle<v8::Value> constructorArgs[3] = {buf, NanNew<v8::Integer>((unsigned)vec.size()), NanNew<v8::Integer>(0)};
-	v8::Local<v8::Object> actualBuffer = bufferConstructor->NewInstance(3, constructorArgs);
+  v8::Local < v8::Object > globalObj = NanGetCurrentContext()->Global();
+  v8::Local < v8::Function > bufferConstructor = v8::Local < v8::Function
+      > ::Cast(globalObj->Get(NanNew<String>("Buffer")));
+  v8::Handle<v8::Value> constructorArgs[3] =
+      {buf, NanNew<v8::Integer>((unsigned)vec.size()), NanNew<v8::Integer>(0)};
+  v8::Local < v8::Object > actualBuffer = bufferConstructor->NewInstance(3,
+      constructorArgs);
 
-	NanReturnValue(actualBuffer);
+  NanReturnValue(actualBuffer);
 }
 
+class AsyncToBufferWorker: public NanAsyncWorker {
+public:
+  AsyncToBufferWorker(NanCallback *callback, Matrix* matrix, string ext,
+      vector<int> params) :
+      NanAsyncWorker(callback),
+      matrix(matrix),
+      ext(ext),
+      params(params) {
+  }
 
+  ~AsyncToBufferWorker() {
+  }
 
-class AsyncToBufferWorker : public NanAsyncWorker {
- public:
-  AsyncToBufferWorker(NanCallback *callback, Matrix* matrix, string ext, vector<int> params )
-    : NanAsyncWorker(callback), matrix(matrix), ext(ext), params(params) {}
-  ~AsyncToBufferWorker() {}
-
-  void Execute () {
+  void Execute() {
     std::vector<uchar> vec(0);
-
-	  //std::vector<int> params(0);//CV_IMWRITE_JPEG_QUALITY 90
-
-	  cv::imencode(ext, this->matrix->mat, vec, this->params);
-
+    // std::vector<int> params(0);//CV_IMWRITE_JPEG_QUALITY 90
+    cv::imencode(ext, this->matrix->mat, vec, this->params);
     res = vec;
   }
 
-  void HandleOKCallback () {
+  void HandleOKCallback() {
     NanScope();
 
     Local<Object> buf = NanNewBufferHandle(res.size());
     uchar* data = (uchar*) Buffer::Data(buf);
     memcpy(data, &res[0], res.size());
 
-	  v8::Local<v8::Object> globalObj = NanGetCurrentContext()->Global();
-	  v8::Local<v8::Function> bufferConstructor = v8::Local<v8::Function>::Cast(globalObj->Get(NanNew<String>("Buffer")));
-	  v8::Handle<v8::Value> constructorArgs[3] = {buf, NanNew<v8::Integer>((unsigned)res.size()), NanNew<v8::Integer>(0)};
-	  v8::Local<v8::Object> actualBuffer = bufferConstructor->NewInstance(3, constructorArgs);
-
+    v8::Local<v8::Object> globalObj = NanGetCurrentContext()->Global();
+    v8::Local<v8::Function> bufferConstructor = v8::Local<v8::Function>::Cast(globalObj->Get(NanNew<String>("Buffer")));
+    v8::Handle<v8::Value> constructorArgs[3] = {buf, NanNew<v8::Integer>((unsigned)res.size()), NanNew<v8::Integer>(0)};
+    v8::Local<v8::Object> actualBuffer = bufferConstructor->NewInstance(3, constructorArgs);
 
     Local<Value> argv[] = {
-        NanNull()
-      , actualBuffer
+      NanNull(),
+      actualBuffer
     };
 
     TryCatch try_catch;
@@ -676,16 +653,15 @@ class AsyncToBufferWorker : public NanAsyncWorker {
 
   }
 
- private:
+private:
   Matrix* matrix;
   std::string ext;
   std::vector<int> params;
-  std::vector<uchar>  res;
+  std::vector<uchar> res;
 };
 
-
-NAN_METHOD(Matrix::ToBufferAsync){
-	SETUP_FUNCTION(Matrix)
+NAN_METHOD(Matrix::ToBufferAsync) {
+  SETUP_FUNCTION(Matrix)
 
   REQ_FUN_ARG(0, cb);
 
@@ -694,205 +670,201 @@ NAN_METHOD(Matrix::ToBufferAsync){
 
   // See if the options argument is passed
   if ((args.Length() > 1) && (args[1]->IsObject())) {
-      // Get this options argument
-      v8::Handle<v8::Object> options = v8::Handle<v8::Object>::Cast(args[1]);
-      // If the extension (image format) is provided
-      if (options->Has(NanNew<String>("ext"))) {
-          v8::String::Utf8Value str ( options->Get(NanNew<String>("ext"))->ToString() );
-          std::string str2 = std::string(*str);
-          ext = str2;
-      }
-      if (options->Has(NanNew<String>("jpegQuality"))) {
-          int compression = options->Get(NanNew<String>("jpegQuality"))->IntegerValue();
-          params.push_back(CV_IMWRITE_JPEG_QUALITY);
-          params.push_back(compression);
-      }
-      if (options->Has(NanNew<String>("pngCompression"))) {
-          int compression = options->Get(NanNew<String>("pngCompression"))->IntegerValue();
-          params.push_back(CV_IMWRITE_PNG_COMPRESSION);
-          params.push_back(compression);
-      }
+    // Get this options argument
+    v8::Handle < v8::Object > options = v8::Handle<v8::Object>::Cast(args[1]);
+    // If the extension (image format) is provided
+    if (options->Has(NanNew<String>("ext"))) {
+      v8::String::Utf8Value str(
+          options->Get(NanNew<String>("ext"))->ToString());
+      std::string str2 = std::string(*str);
+      ext = str2;
+    }
+    if (options->Has(NanNew<String>("jpegQuality"))) {
+      int compression =
+          options->Get(NanNew<String>("jpegQuality"))->IntegerValue();
+      params.push_back(CV_IMWRITE_JPEG_QUALITY);
+      params.push_back(compression);
+    }
+    if (options->Has(NanNew<String>("pngCompression"))) {
+      int compression =
+          options->Get(NanNew<String>("pngCompression"))->IntegerValue();
+      params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+      params.push_back(compression);
+    }
   }
 
-
   NanCallback *callback = new NanCallback(cb.As<Function>());
-
   NanAsyncQueueWorker(new AsyncToBufferWorker(callback, self, ext, params));
 
   NanReturnUndefined();
 }
 
+NAN_METHOD(Matrix::Ellipse) {
+  SETUP_FUNCTION(Matrix)
 
-NAN_METHOD(Matrix::Ellipse){
-	SETUP_FUNCTION(Matrix)
+  int x = 0;
+  int y = 0;
+  int width = 0;
+  int height = 0;
+  cv::Scalar color(0, 0, 255);
+  int thickness = 1;
+  double angle = 0;
+  double startAngle = 0;
+  double endAngle = 360;
+  int lineType = 8;
+  int shift = 0;
 
-	int x = 0;
-	int y = 0;
-	int width = 0;
-	int height = 0;
-	cv::Scalar color(0, 0, 255);
-	int thickness = 1;
-	double angle = 0;
-	double startAngle = 0;
-	double endAngle = 360;
-	int lineType = 8;
-	int shift = 0;
+  if (args[0]->IsObject()) {
+    v8::Handle < v8::Object > options = v8::Handle<v8::Object>::Cast(args[0]);
+    if (options->Has(NanNew<String>("center"))) {
+      Local < Object > center =
+          options->Get(NanNew<String>("center"))->ToObject();
+      x = center->Get(NanNew<String>("x"))->Uint32Value();
+      y = center->Get(NanNew<String>("y"))->Uint32Value();
+    }
+    if (options->Has(NanNew<String>("axes"))) {
+      Local < Object > axes = options->Get(NanNew<String>("axes"))->ToObject();
+      width = axes->Get(NanNew<String>("width"))->Uint32Value();
+      height = axes->Get(NanNew<String>("height"))->Uint32Value();
+    }
+    if (options->Has(NanNew<String>("thickness"))) {
+      thickness = options->Get(NanNew<String>("thickness"))->Uint32Value();
+    }
+    if (options->Has(NanNew<String>("angle"))) {
+      angle = options->Get(NanNew<String>("angle"))->NumberValue();
+    }
+    if (options->Has(NanNew<String>("startAngle"))) {
+      startAngle = options->Get(NanNew<String>("startAngle"))->NumberValue();
+    }
+    if (options->Has(NanNew<String>("endAngle"))) {
+      endAngle = options->Get(NanNew<String>("endAngle"))->NumberValue();
+    }
+    if (options->Has(NanNew<String>("lineType"))) {
+      lineType = options->Get(NanNew<String>("lineType"))->Uint32Value();
+    }
+    if (options->Has(NanNew<String>("shift"))) {
+      shift = options->Get(NanNew<String>("shift"))->Uint32Value();
+    }
+    if (options->Has(NanNew<String>("color"))) {
+      Local < Object > objColor =
+          options->Get(NanNew<String>("color"))->ToObject();
+      color = setColor(objColor);
+    }
+  } else {
+    x = args[0]->Uint32Value();
+    y = args[1]->Uint32Value();
+    width = args[2]->Uint32Value();
+    height = args[3]->Uint32Value();
 
-	if(args[0]->IsObject()) {
-		v8::Handle<v8::Object> options = v8::Handle<v8::Object>::Cast(args[0]);
-		if (options->Has(NanNew<String>("center"))) {
-		  Local<Object> center = options->Get(NanNew<String>("center"))->ToObject();
-		  x = center->Get(NanNew<String>("x"))->Uint32Value();
-		  y = center->Get(NanNew<String>("y"))->Uint32Value();
-		}
-		if (options->Has(NanNew<String>("axes"))) {
-		  Local<Object> axes = options->Get(NanNew<String>("axes"))->ToObject();
-		  width = axes->Get(NanNew<String>("width"))->Uint32Value();
-		  height = axes->Get(NanNew<String>("height"))->Uint32Value();
-		}
-		if (options->Has(NanNew<String>("thickness"))) {
-			thickness = options->Get(NanNew<String>("thickness"))->Uint32Value();
-		}
-		if (options->Has(NanNew<String>("angle"))) {
-			angle = options->Get(NanNew<String>("angle"))->NumberValue();
-		}
-		if (options->Has(NanNew<String>("startAngle"))) {
-			startAngle = options->Get(NanNew<String>("startAngle"))->NumberValue();
-		}
-		if (options->Has(NanNew<String>("endAngle"))) {
-			endAngle = options->Get(NanNew<String>("endAngle"))->NumberValue();
-		}
-		if (options->Has(NanNew<String>("lineType"))) {
-			lineType = options->Get(NanNew<String>("lineType"))->Uint32Value();
-		}
-		if (options->Has(NanNew<String>("shift"))) {
-			shift = options->Get(NanNew<String>("shift"))->Uint32Value();
-		}
-		if (options->Has(NanNew<String>("color"))) {
-			Local<Object> objColor = options->Get(NanNew<String>("color"))->ToObject();
-			color = setColor(objColor);
-		}
-	} else {
-		x = args[0]->Uint32Value();
-		y = args[1]->Uint32Value();
-		width = args[2]->Uint32Value();
-		height = args[3]->Uint32Value();
+    if (args[4]->IsArray()) {
+      Local < Object > objColor = args[4]->ToObject();
+      color = setColor(objColor);
+    }
 
-		if(args[4]->IsArray()) {
-			Local<Object> objColor = args[4]->ToObject();
-			color = setColor(objColor);
-		}
+    if (args[5]->IntegerValue())
+      thickness = args[5]->IntegerValue();
+  }
 
-		if(args[5]->IntegerValue())
-			thickness = args[5]->IntegerValue();
-	}
-
-	cv::ellipse(self->mat, cv::Point(x, y), cv::Size(width, height), angle, startAngle, endAngle, color, thickness, lineType, shift);
-	NanReturnNull();
+  cv::ellipse(self->mat, cv::Point(x, y), cv::Size(width, height), angle,
+      startAngle, endAngle, color, thickness, lineType, shift);
+  NanReturnNull();
 }
 
-
-
 NAN_METHOD(Matrix::Rectangle) {
-	SETUP_FUNCTION(Matrix)
+  SETUP_FUNCTION(Matrix)
 
+  if (args[0]->IsArray() && args[1]->IsArray()) {
+    Local < Object > xy = args[0]->ToObject();
+    Local < Object > width_height = args[1]->ToObject();
 
-	if(args[0]->IsArray() && args[1]->IsArray()) {
-		Local<Object> xy = args[0]->ToObject();
-		Local<Object> width_height = args[1]->ToObject();
+    cv::Scalar color(0, 0, 255);
 
-		cv::Scalar color(0, 0, 255);
+    if (args[2]->IsArray()) {
+      Local < Object > objColor = args[2]->ToObject();
+      color = setColor(objColor);
+    }
 
-		if(args[2]->IsArray()) {
-			Local<Object> objColor = args[2]->ToObject();
-			color = setColor(objColor);
-		}
+    int x = xy->Get(0)->IntegerValue();
+    int y = xy->Get(1)->IntegerValue();
 
-		int x = xy->Get(0)->IntegerValue();
-		int y = xy->Get(1)->IntegerValue();
+    int width = width_height->Get(0)->IntegerValue();
+    int height = width_height->Get(1)->IntegerValue();
 
-		int width = width_height->Get(0)->IntegerValue();
-		int height = width_height->Get(1)->IntegerValue();
+    int thickness = 1;
 
-		int thickness = 1;
+    if (args[3]->IntegerValue())
+      thickness = args[3]->IntegerValue();
 
-		if(args[3]->IntegerValue())
-			thickness = args[3]->IntegerValue();
+    cv::rectangle(self->mat, cv::Point(x, y), cv::Point(x + width, y + height),
+        color, thickness);
+  }
 
-		cv::rectangle(self->mat, cv::Point(x, y), cv::Point(x+width, y+height), color, thickness);
-	}
-
-	NanReturnNull();
+  NanReturnNull();
 }
 
 NAN_METHOD(Matrix::Line) {
-	SETUP_FUNCTION(Matrix)
+  SETUP_FUNCTION(Matrix)
 
+  if (args[0]->IsArray() && args[1]->IsArray()) {
+    Local < Object > xy1 = args[0]->ToObject();
+    Local < Object > xy2 = args[1]->ToObject();
 
-	if(args[0]->IsArray() && args[1]->IsArray()) {
-		Local<Object> xy1 = args[0]->ToObject();
-		Local<Object> xy2 = args[1]->ToObject();
+    cv::Scalar color(0, 0, 255);
 
-		cv::Scalar color(0, 0, 255);
+    if (args[2]->IsArray()) {
+      Local < Object > objColor = args[2]->ToObject();
+      color = setColor(objColor);
+    }
 
-		if(args[2]->IsArray()) {
-			Local<Object> objColor = args[2]->ToObject();
-			color = setColor(objColor);
-		}
+    int x1 = xy1->Get(0)->IntegerValue();
+    int y1 = xy1->Get(1)->IntegerValue();
 
-		int x1 = xy1->Get(0)->IntegerValue();
-		int y1 = xy1->Get(1)->IntegerValue();
+    int x2 = xy2->Get(0)->IntegerValue();
+    int y2 = xy2->Get(1)->IntegerValue();
 
-		int x2 = xy2->Get(0)->IntegerValue();
-		int y2 = xy2->Get(1)->IntegerValue();
+    int thickness = 1;
 
-		int thickness = 1;
+    if (args[3]->IntegerValue())
+      thickness = args[3]->IntegerValue();
 
-		if(args[3]->IntegerValue())
-			thickness = args[3]->IntegerValue();
+    cv::line(self->mat, cv::Point(x1, y1), cv::Point(x2, y2), color, thickness);
+  }
 
-		cv::line(self->mat, cv::Point(x1, y1), cv::Point(x2, y2), color, thickness);
-	}
-
-	NanReturnNull();
+  NanReturnNull();
 }
 
 NAN_METHOD(Matrix::FillPoly) {
-	SETUP_FUNCTION(Matrix)
+  SETUP_FUNCTION(Matrix)
 
-	if(args[0]->IsArray())
-	{
-		Local<Array> polyArray = Local<Array>::Cast(args[0]->ToObject());
+  if (args[0]->IsArray()) {
+    Local < Array > polyArray = Local < Array > ::Cast(args[0]->ToObject());
 
-		cv::Point **polygons = new cv::Point*[polyArray->Length()];
-		int *polySizes = new int[polyArray->Length()];
-		for(unsigned int i = 0; i < polyArray->Length(); i++)
-		{
-			Local<Array> singlePoly = Local<Array>::Cast(polyArray->Get(i)->ToObject());
-			polygons[i] = new cv::Point[singlePoly->Length()];
-			polySizes[i] = singlePoly->Length();
+    cv::Point **polygons = new cv::Point*[polyArray->Length()];
+    int *polySizes = new int[polyArray->Length()];
+    for (unsigned int i = 0; i < polyArray->Length(); i++) {
+      Local<Array> singlePoly = Local<Array> ::Cast(polyArray->Get(i)->ToObject());
+      polygons[i] = new cv::Point[singlePoly->Length()];
+      polySizes[i] = singlePoly->Length();
 
-			for(unsigned int j = 0; j < singlePoly->Length(); j++)
-			{
-				Local<Array> point = Local<Array>::Cast(singlePoly->Get(j)->ToObject());
-				polygons[i][j].x = point->Get(0)->IntegerValue();
-				polygons[i][j].y = point->Get(1)->IntegerValue();
-			}
-		}
+      for (unsigned int j = 0; j < singlePoly->Length(); j++) {
+        Local<Array> point = Local<Array> ::Cast(singlePoly->Get(j)->ToObject());
+        polygons[i][j].x = point->Get(0)->IntegerValue();
+        polygons[i][j].y = point->Get(1)->IntegerValue();
+      }
+    }
 
-		cv::Scalar color(0, 0, 255);
+    cv::Scalar color(0, 0, 255);
+    if (args[1]->IsArray()) {
+      Local<Object> objColor = args[1]->ToObject();
+      color = setColor(objColor);
+    }
 
-		if(args[1]->IsArray()) {
-			Local<Object> objColor = args[1]->ToObject();
-			color = setColor(objColor);
-		}
+    cv::fillPoly(self->mat, (const cv::Point **) polygons, polySizes,
+        polyArray->Length(), color);
+  }
 
-		cv::fillPoly(self->mat, (const cv::Point **)polygons, polySizes, polyArray->Length(), color);
-	}
-
-	NanReturnNull();
+  NanReturnNull();
 }
-
 
 NAN_METHOD(Matrix::Save) {
   SETUP_FUNCTION(Matrix)
@@ -901,39 +873,46 @@ NAN_METHOD(Matrix::Save) {
     return SaveAsync(args);
   }
 
-  if (!args[0]->IsString())
+  if (!args[0]->IsString()) {
     NanThrowTypeError("filename required");
+  }
 
   NanAsciiString filename(args[0]);
   int res = cv::imwrite(*filename, self->mat);
+
   NanReturnValue(NanNew<Number>(res));
 }
 
+// All this is for async save, see here for nan example:
+// https://github.com/rvagg/nan/blob/c579ae858ae3208d7e702e8400042ba9d48fa64b/examples/async_pi_estimate/async.cc
+class AsyncSaveWorker: public NanAsyncWorker {
+public:
+  AsyncSaveWorker(NanCallback *callback, Matrix* matrix, char* filename) :
+      NanAsyncWorker(callback),
+      matrix(matrix),
+      filename(filename) {
+  }
 
-//All this is for async save, see here for nan example: https://github.com/rvagg/nan/blob/c579ae858ae3208d7e702e8400042ba9d48fa64b/examples/async_pi_estimate/async.cc
-class AsyncSaveWorker : public NanAsyncWorker {
- public:
-  AsyncSaveWorker(NanCallback *callback, Matrix* matrix, char* filename)
-    : NanAsyncWorker(callback), matrix(matrix), filename(filename) {}
-  ~AsyncSaveWorker() {}
+  ~AsyncSaveWorker() {
+  }
 
   // Executed inside the worker-thread.
   // It is not safe to access V8, or V8 data structures
   // here, so everything we need for input and output
   // should go on `this`.
-  void Execute () {
+  void Execute() {
     res = cv::imwrite(this->filename, this->matrix->mat);
   }
 
   // Executed when the async work is complete
   // this function will be run inside the main event loop
   // so it is safe to use V8 again
-  void HandleOKCallback () {
+  void HandleOKCallback() {
     NanScope();
 
     Local<Value> argv[] = {
-        NanNull()
-      , NanNew<Number>(res)
+      NanNull(),
+      NanNew<Number>(res)
     };
 
     TryCatch try_catch;
@@ -943,19 +922,18 @@ class AsyncSaveWorker : public NanAsyncWorker {
     }
   }
 
- private:
+private:
   Matrix* matrix;
   char* filename;
-  int  res;
+  int res;
 };
 
-
-
-NAN_METHOD(Matrix::SaveAsync){
+NAN_METHOD(Matrix::SaveAsync) {
   SETUP_FUNCTION(Matrix)
 
-  if (!args[0]->IsString())
+  if (!args[0]->IsString()) {
     NanThrowTypeError("filename required");
+  }
 
   NanAsciiString filename(args[0]);
 
@@ -967,7 +945,7 @@ NAN_METHOD(Matrix::SaveAsync){
   NanReturnUndefined();
 }
 
-NAN_METHOD(Matrix::Zeros){
+NAN_METHOD(Matrix::Zeros) {
   NanScope();
 
   int w = args[0]->Uint32Value();
@@ -982,7 +960,7 @@ NAN_METHOD(Matrix::Zeros){
   NanReturnValue(im_h);
 }
 
-NAN_METHOD(Matrix::Ones){
+NAN_METHOD(Matrix::Ones) {
   NanScope();
 
   int w = args[0]->Uint32Value();
@@ -997,84 +975,82 @@ NAN_METHOD(Matrix::Ones){
   NanReturnValue(im_h);
 }
 
-NAN_METHOD(Matrix::Eye){
-	NanScope();
+NAN_METHOD(Matrix::Eye) {
+  NanScope();
 
-	int w = args[0]->Uint32Value();
-	int h = args[1]->Uint32Value();
+  int w = args[0]->Uint32Value();
+  int h = args[1]->Uint32Value();
   int type = (args.Length() > 2) ? args[2]->IntegerValue() : CV_64FC1;
 
-	Local<Object> im_h = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-	Matrix *img = ObjectWrap::Unwrap<Matrix>(im_h);
-	cv::Mat mat = cv::Mat::eye(w, h, type);
+  Local<Object> im_h = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+  Matrix *img = ObjectWrap::Unwrap<Matrix>(im_h);
+  cv::Mat mat = cv::Mat::eye(w, h, type);
 
-	img->mat = mat;
-	NanReturnValue(im_h);
+  img->mat = mat;
+  NanReturnValue(im_h);
 }
 
 NAN_METHOD(Matrix::ConvertGrayscale) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-	if(self->mat.channels() != 3)
-		NanThrowError("Image is no 3-channel");
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  if (self->mat.channels() != 3) {
+    NanThrowError("Image is no 3-channel");
+  }
 
-	cv::Mat gray;
+  cv::Mat gray;
 
-	cv::cvtColor(self->mat, gray, CV_BGR2GRAY);
-	gray.copyTo(self->mat);
+  cv::cvtColor(self->mat, gray, CV_BGR2GRAY);
+  gray.copyTo(self->mat);
 
-
-	NanReturnNull();
+  NanReturnNull();
 }
-
 
 NAN_METHOD(Matrix::ConvertHSVscale) {
-    NanScope();
+  NanScope();
 
-    Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-    if(self->mat.channels() != 3)
-        NanThrowError("Image is no 3-channel");
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  if (self->mat.channels() != 3) {
+    NanThrowError("Image is no 3-channel");
+  }
 
-    cv::Mat hsv;
+  cv::Mat hsv;
 
-    cv::cvtColor(self->mat, hsv, CV_BGR2HSV);
-    hsv.copyTo(self->mat);
+  cv::cvtColor(self->mat, hsv, CV_BGR2HSV);
+  hsv.copyTo(self->mat);
 
-    NanReturnNull();
+  NanReturnNull();
 }
-
 
 NAN_METHOD(Matrix::GaussianBlur) {
-	NanScope();
-    cv::Size ksize;
-	  cv::Mat blurred;
+  NanScope();
+  cv::Size ksize;
+  cv::Mat blurred;
 
-    Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
 
-    if (args.Length() < 1) {
-        ksize = cv::Size(5, 5);
+  if (args.Length() < 1) {
+    ksize = cv::Size(5, 5);
+  }
+  else {
+    if (!args[0]->IsArray()) {
+      NanThrowTypeError("'ksize' argument must be a 2 double array");
     }
-    else {
-        if(!args[0]->IsArray()) {
-            NanThrowTypeError("'ksize' argument must be a 2 double array");
-        }
-        Local<Object> array = args[0]->ToObject();
-        // TODO: Length check
-        Local<Value> x = array->Get(0);
-        Local<Value> y = array->Get(1);
-        if(!x->IsNumber() || !y->IsNumber()) {
-            NanThrowTypeError("'ksize' argument must be a 2 double array");
-        }
-        ksize = cv::Size(x->NumberValue(), y->NumberValue());
+    Local<Object> array = args[0]->ToObject();
+    // TODO: Length check
+    Local<Value> x = array->Get(0);
+    Local<Value> y = array->Get(1);
+    if (!x->IsNumber() || !y->IsNumber()) {
+      NanThrowTypeError("'ksize' argument must be a 2 double array");
     }
+    ksize = cv::Size(x->NumberValue(), y->NumberValue());
+  }
 
-	cv::GaussianBlur(self->mat, blurred, ksize, 0);
-	blurred.copyTo(self->mat);
+  cv::GaussianBlur(self->mat, blurred, ksize, 0);
+  blurred.copyTo(self->mat);
 
-	NanReturnNull();
+  NanReturnNull();
 }
-
 
 NAN_METHOD(Matrix::MedianBlur) {
   NanScope();
@@ -1096,7 +1072,6 @@ NAN_METHOD(Matrix::MedianBlur) {
 
   NanReturnNull();
 }
-
 
 NAN_METHOD(Matrix::BilateralFilter) {
   NanScope();
@@ -1127,224 +1102,210 @@ NAN_METHOD(Matrix::BilateralFilter) {
   NanReturnNull();
 }
 
-
 NAN_METHOD(Matrix::Copy) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
 
-  Local<Object> img_to_return = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-	Matrix *img = ObjectWrap::Unwrap<Matrix>(img_to_return);
-	self->mat.copyTo(img->mat);
+  Local<Object> img_to_return =
+      NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+  Matrix *img = ObjectWrap::Unwrap<Matrix>(img_to_return);
+  self->mat.copyTo(img->mat);
 
-	NanReturnValue(img_to_return);
+  NanReturnValue(img_to_return);
 }
-
 
 NAN_METHOD(Matrix::Flip) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
 
-	if ( args.Length() < 1 || !args[0]->IsInt32() ) {
-		NanThrowTypeError("Flip requires an integer flipCode argument (0 = X axis, positive = Y axis, negative = both axis)");
-	}
+  if ( args.Length() < 1 || !args[0]->IsInt32() ) {
+    NanThrowTypeError("Flip requires an integer flipCode argument "
+        "(0 = X axis, positive = Y axis, negative = both axis)");
+  }
 
-	int flipCode = args[0]->ToInt32()->Value();
+  int flipCode = args[0]->ToInt32()->Value();
 
   Local<Object> img_to_return = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-	Matrix *img = ObjectWrap::Unwrap<Matrix>(img_to_return);
-	cv::flip(self->mat, img->mat, flipCode);
+  Matrix *img = ObjectWrap::Unwrap<Matrix>(img_to_return);
+  cv::flip(self->mat, img->mat, flipCode);
 
-	NanReturnValue(img_to_return);
+  NanReturnValue(img_to_return);
 }
-
 
 NAN_METHOD(Matrix::ROI) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
 
-	if ( args.Length() != 4 ) {
-		NanThrowTypeError("ROI requires x,y,w,h arguments");
-	}
+  if ( args.Length() != 4 ) {
+    NanThrowTypeError("ROI requires x,y,w,h arguments");
+  }
 
-	// although it's an image to return, it is in fact a pointer to ROI of parent matrix
+  // Although it's an image to return, it is in fact a pointer to ROI of parent matrix
   Local<Object> img_to_return = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-	Matrix *img = ObjectWrap::Unwrap<Matrix>(img_to_return);
+  Matrix *img = ObjectWrap::Unwrap<Matrix>(img_to_return);
 
-	int x = args[0]->IntegerValue();
-	int y = args[1]->IntegerValue();
-	int w = args[2]->IntegerValue();
-	int h = args[3]->IntegerValue();
+  int x = args[0]->IntegerValue();
+  int y = args[1]->IntegerValue();
+  int w = args[2]->IntegerValue();
+  int h = args[3]->IntegerValue();
 
-	cv::Mat roi(self->mat, cv::Rect(x,y,w,h));
-	img->mat = roi;
+  cv::Mat roi(self->mat, cv::Rect(x,y,w,h));
+  img->mat = roi;
 
-	NanReturnValue(img_to_return);
+  NanReturnValue(img_to_return);
 }
 
-
 NAN_METHOD(Matrix::Ptr) {
-	NanScope();
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-	int line = args[0]->Uint32Value();
+  NanScope();
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  int line = args[0]->Uint32Value();
 
-	char* data = self->mat.ptr<char>(line);
-	//uchar* data = self->mat.data;
+  char* data = self->mat.ptr<char>(line);
+  // uchar* data = self->mat.data;
 
-/*
-  char *mydata = "Random raw data\0";
-*/
+  // char *mydata = "Random raw data\0";
   Local<Object> return_buffer = NanNewBufferHandle((char*)data, self->mat.step);
   NanReturnValue( return_buffer );
 //  NanReturnUndefined();
 }
+
 NAN_METHOD(Matrix::AbsDiff) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *src1 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+  Matrix *src2 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
+  cv::absdiff(src1->mat, src2->mat, self->mat);
 
-	Matrix *src1 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-	Matrix *src2 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
-
-	cv::absdiff(src1->mat, src2->mat, self->mat);
-
-	NanReturnNull();
+  NanReturnNull();
 }
 
 NAN_METHOD(Matrix::AddWeighted) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *src1 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+  Matrix *src2 = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
 
-	Matrix *src1 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-	Matrix *src2 = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
+  float alpha = args[1]->NumberValue();
+  float beta = args[3]->NumberValue();
+  int gamma = 0;
 
-	float alpha = args[1]->NumberValue();
-	float beta = args[3]->NumberValue();
-	int gamma = 0;
-
-  try{
-	  cv::addWeighted(src1->mat, alpha, src2->mat, beta, gamma, self->mat);
-  } catch(cv::Exception& e ){
+  try {
+    cv::addWeighted(src1->mat, alpha, src2->mat, beta, gamma, self->mat);
+  } catch(cv::Exception& e ) {
     const char* err_msg = e.what();
     NanThrowError(err_msg);
   }
 
-
-	NanReturnNull();
+  NanReturnNull();
 }
 
 NAN_METHOD(Matrix::BitwiseXor) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *src1 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+  Matrix *src2 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
 
-	Matrix *src1 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-	Matrix *src2 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
+  if (args.Length() == 3) {
+    Matrix *mask = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
+    cv::bitwise_xor(src1->mat, src2->mat, self->mat, mask->mat);
+  } else {
+    cv::bitwise_xor(src1->mat, src2->mat, self->mat);
+  }
 
-    if(args.Length() == 3){
-    	Matrix *mask = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
-		cv::bitwise_xor(src1->mat, src2->mat, self->mat, mask->mat);
-    }else{
-		cv::bitwise_xor(src1->mat, src2->mat, self->mat);
-    }
-
-	NanReturnNull();
+  NanReturnNull();
 }
 
 NAN_METHOD(Matrix::BitwiseNot) {
-    NanScope();
+  NanScope();
 
-    Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *dst = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+  if (args.Length() == 2) {
+    Matrix *mask = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
+    cv::bitwise_not(self->mat, dst->mat, mask->mat);
+  } else {
+    cv::bitwise_not(self->mat, dst->mat);
+  }
 
-    Matrix *dst = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-
-    if(args.Length() == 2){
-    	Matrix *mask = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
-    	cv::bitwise_not(self->mat, dst->mat, mask->mat);
-    }else{
-    	cv::bitwise_not(self->mat, dst->mat);
-    }
-
-    NanReturnNull();
+  NanReturnNull();
 }
 
 NAN_METHOD(Matrix::BitwiseAnd) {
-    NanScope();
+  NanScope();
 
-    Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *src1 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+  Matrix *src2 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
+  if (args.Length() == 3) {
+    Matrix *mask = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
+    cv::bitwise_and(src1->mat, src2->mat, self->mat, mask->mat);
+  } else {
+    cv::bitwise_and(src1->mat, src2->mat, self->mat);
+  }
 
-    Matrix *src1 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-    Matrix *src2 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
-
-    if(args.Length() == 3){
-    	Matrix *mask = ObjectWrap::Unwrap<Matrix>(args[2]->ToObject());
-	    cv::bitwise_and(src1->mat, src2->mat, self->mat, mask->mat);
-    }else{
-	    cv::bitwise_and(src1->mat, src2->mat, self->mat);
-    }
-
-    NanReturnNull();
+  NanReturnNull();
 }
 
 NAN_METHOD(Matrix::CountNonZero) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  double count = (double)cv::countNonZero(self->mat);
 
-	double count = (double)cv::countNonZero(self->mat);
-	NanReturnValue(NanNew<Number>(count));
+  NanReturnValue(NanNew<Number>(count));
 }
 
-/*NAN_METHOD(Matrix::Split) {
-	NanScope();
+/*
+NAN_METHOD(Matrix::Split) {
+  NanScope();
 
-	//Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  //Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
 
-	NanReturnNull();
-}*/
-
+  NanReturnNull();
+} */
 
 NAN_METHOD(Matrix::Canny) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-	int lowThresh = args[0]->NumberValue();
-	int highThresh = args[1]->NumberValue();
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  int lowThresh = args[0]->NumberValue();
+  int highThresh = args[1]->NumberValue();
 
-	cv::Canny(self->mat, self->mat, lowThresh, highThresh);
+  cv::Canny(self->mat, self->mat, lowThresh, highThresh);
 
-	NanReturnNull();
+  NanReturnNull();
 }
 
-
 NAN_METHOD(Matrix::Dilate) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-	int niters = args[0]->NumberValue();
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  int niters = args[0]->NumberValue();
 
-	cv::dilate(self->mat, self->mat, cv::Mat(), cv::Point(-1, -1), niters);
+  cv::dilate(self->mat, self->mat, cv::Mat(), cv::Point(-1, -1), niters);
 
-	NanReturnNull();
+  NanReturnNull();
 }
 
 NAN_METHOD(Matrix::Erode) {
-    NanScope();
+  NanScope();
 
-    Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-    int niters = args[0]->NumberValue();
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  int niters = args[0]->NumberValue();
 
-    cv::erode(self->mat, self->mat, cv::Mat(), cv::Point(-1, -1), niters);
+  cv::erode(self->mat, self->mat, cv::Mat(), cv::Point(-1, -1), niters);
 
-    NanReturnNull();
+  NanReturnNull();
 }
 
-
 NAN_METHOD(Matrix::FindContours) {
-	NanScope();
+  NanScope();
 
   int mode = CV_RETR_LIST;
   int chain = CV_CHAIN_APPROX_SIMPLE;
@@ -1357,78 +1318,67 @@ NAN_METHOD(Matrix::FindContours) {
     if (args[1]->IsNumber()) chain = args[1]->IntegerValue();
   }
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-	Local<Object> conts_to_return= NanNew(Contour::constructor)->GetFunction()->NewInstance();
-	Contour *contours = ObjectWrap::Unwrap<Contour>(conts_to_return);
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Local<Object> conts_to_return= NanNew(Contour::constructor)->GetFunction()->NewInstance();
+  Contour *contours = ObjectWrap::Unwrap<Contour>(conts_to_return);
 
-	cv::findContours(self->mat, contours->contours, contours->hierarchy, mode, chain);
+  cv::findContours(self->mat, contours->contours, contours->hierarchy, mode, chain);
 
-	NanReturnValue(conts_to_return);
+  NanReturnValue(conts_to_return);
 
 }
-
 
 NAN_METHOD(Matrix::DrawContour) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-	Contour *cont = ObjectWrap::Unwrap<Contour>(args[0]->ToObject());
-	int pos = args[1]->NumberValue();
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Contour *cont = ObjectWrap::Unwrap<Contour>(args[0]->ToObject());
+  int pos = args[1]->NumberValue();
+  cv::Scalar color(0, 0, 255);
 
-	cv::Scalar color(0, 0, 255);
+  if (args[2]->IsArray()) {
+    Local<Object> objColor = args[2]->ToObject();
+    color = setColor(objColor);
+  }
 
-	if(args[2]->IsArray()) {
-		Local<Object> objColor = args[2]->ToObject();
-		color = setColor(objColor);
-	}
+  int thickness = args.Length() < 4 ? 1 : args[3]->NumberValue();
+  cv::drawContours(self->mat, cont->contours, pos, color, thickness);
 
-    int thickness = args.Length() < 4 ? 1 : args[3]->NumberValue();
-
-    cv::drawContours(self->mat, cont->contours, pos, color, thickness);
-
-	NanReturnUndefined();
+  NanReturnUndefined();
 }
-
 
 NAN_METHOD(Matrix::DrawAllContours) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-	Contour *cont = ObjectWrap::Unwrap<Contour>(args[0]->ToObject());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Contour *cont = ObjectWrap::Unwrap<Contour>(args[0]->ToObject());
+  cv::Scalar color(0, 0, 255);
 
-	cv::Scalar color(0, 0, 255);
+  if (args[1]->IsArray()) {
+    Local<Object> objColor = args[1]->ToObject();
+    color = setColor(objColor);
+  }
 
-	if(args[1]->IsArray()) {
-		Local<Object> objColor = args[1]->ToObject();
-		color = setColor(objColor);
-	}
+  int thickness = args.Length() < 3 ? 1 : args[2]->NumberValue();
+  cv::drawContours(self->mat, cont->contours, -1, color, thickness);
 
-    int thickness = args.Length() < 3 ? 1 : args[2]->NumberValue();
-
-    cv::drawContours(self->mat, cont->contours, -1, color, thickness);
-
-
-	NanReturnUndefined();
+  NanReturnUndefined();
 }
 
-
 NAN_METHOD(Matrix::GoodFeaturesToTrack) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
   std::vector<cv::Point2f> corners;
-
   cv::Mat gray;
 
-	cvtColor(self->mat, gray, CV_BGR2GRAY);
+  cvtColor(self->mat, gray, CV_BGR2GRAY);
   equalizeHist(gray, gray);
 
   cv::goodFeaturesToTrack(gray, corners, 500, 0.01, 10);
-
   v8::Local<v8::Array> arr = NanNew<Array>(corners.size());
 
-
-  for (unsigned int i=0; i<corners.size(); i++){
+  for (unsigned int i=0; i<corners.size(); i++) {
     v8::Local<v8::Array> pt = NanNew<Array>(2);
     pt->Set(0, NanNew<Number>((double) corners[i].x));
     pt->Set(1, NanNew<Number>((double) corners[i].y));
@@ -1436,14 +1386,12 @@ NAN_METHOD(Matrix::GoodFeaturesToTrack) {
   }
 
   NanReturnValue(arr);
-
 }
 
-
 NAN_METHOD(Matrix::HoughLinesP) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
   double rho = args.Length() < 1 ? 1 : args[0]->NumberValue();
   double theta = args.Length() < 2 ? CV_PI/180 : args[1]->NumberValue();
   int threshold = args.Length() < 3 ? 80 : args[2]->Uint32Value();
@@ -1453,15 +1401,13 @@ NAN_METHOD(Matrix::HoughLinesP) {
 
   cv::Mat gray;
 
-
   equalizeHist(self->mat, gray);
- // cv::Canny(gray, gray, 50, 200, 3);
+  // cv::Canny(gray, gray, 50, 200, 3);
   cv::HoughLinesP(gray, lines, rho, theta, threshold, minLineLength, maxLineGap);
 
   v8::Local<v8::Array> arr = NanNew<Array>(lines.size());
 
-
-  for (unsigned int i=0; i<lines.size(); i++){
+  for (unsigned int i=0; i<lines.size(); i++) {
     v8::Local<v8::Array> pt = NanNew<Array>(4);
     pt->Set(0, NanNew<Number>((double) lines[i][0]));
     pt->Set(1, NanNew<Number>((double) lines[i][1]));
@@ -1471,13 +1417,12 @@ NAN_METHOD(Matrix::HoughLinesP) {
   }
 
   NanReturnValue(arr);
-
 }
 
 NAN_METHOD(Matrix::HoughCircles) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
 
   double dp = args.Length() < 1 ? 1 : args[0]->NumberValue();
   double minDist = args.Length() < 2 ? 1 : args[1]->NumberValue();
@@ -1489,73 +1434,69 @@ NAN_METHOD(Matrix::HoughCircles) {
 
   cv::Mat gray;
 
-
   equalizeHist(self->mat, gray);
 
-  cv::HoughCircles(gray, circles, CV_HOUGH_GRADIENT, dp, minDist, higherThreshold, accumulatorThreshold, minRadius, maxRadius);
+  cv::HoughCircles(gray, circles, CV_HOUGH_GRADIENT, dp, minDist,
+      higherThreshold, accumulatorThreshold, minRadius, maxRadius);
 
   v8::Local<v8::Array> arr = NanNew<Array>(circles.size());
 
-
-  for (unsigned int i=0; i < circles.size(); i++){
+  for (unsigned int i=0; i < circles.size(); i++) {
     v8::Local<v8::Array> pt = NanNew<Array>(3);
-    pt->Set(0, NanNew<Number>((double) circles[i][0]));// center x
+    pt->Set(0, NanNew<Number>((double) circles[i][0]));  // center x
     pt->Set(1, NanNew<Number>((double) circles[i][1]));// center y
     pt->Set(2, NanNew<Number>((double) circles[i][2]));// radius
     arr->Set(i, pt);
   }
 
   NanReturnValue(arr);
-
 }
 
 cv::Scalar setColor(Local<Object> objColor) {
+  Local<Value> valB = objColor->Get(0);
+  Local<Value> valG = objColor->Get(1);
+  Local<Value> valR = objColor->Get(2);
 
-	Local<Value> valB = objColor->Get(0);
-	Local<Value> valG = objColor->Get(1);
-	Local<Value> valR = objColor->Get(2);
-
-	cv::Scalar color = cv::Scalar(valB->IntegerValue(), valG->IntegerValue(), valR->IntegerValue());
-	return color;
-
-
+  cv::Scalar color = cv::Scalar(valB->IntegerValue(), valG->IntegerValue(),
+      valR->IntegerValue());
+  return color;
 }
 
 cv::Point setPoint(Local<Object> objPoint) {
-	return  cv::Point( objPoint->Get(0)->IntegerValue(),  objPoint->Get(1)->IntegerValue() );
+  return cv::Point(objPoint->Get(0)->IntegerValue(),
+      objPoint->Get(1)->IntegerValue());
 }
 
 cv::Rect* setRect(Local<Object> objRect, cv::Rect &result) {
+  if (!objRect->IsArray() || !objRect->Get(0)->IsArray()
+      || !objRect->Get(0)->IsArray()) {
+    printf("error");
+    return 0;
+  };
 
-	if(!objRect->IsArray() || !objRect->Get(0)->IsArray() || !objRect->Get(0)->IsArray() ){
-		printf("error");
-		return  0;
-	};
+  Local < Object > point = objRect->Get(0)->ToObject();
+  Local < Object > size = objRect->Get(1)->ToObject();
 
-	Local<Object> point = objRect->Get(0)->ToObject();
-	Local<Object> size = objRect->Get(1)->ToObject();
+  result.x = point->Get(0)->IntegerValue();
+  result.y = point->Get(1)->IntegerValue();
+  result.width = size->Get(0)->IntegerValue();
+  result.height = size->Get(1)->IntegerValue();
 
-	result.x = point->Get(0)->IntegerValue();
-	result.y = point->Get(1)->IntegerValue();
-	result.width = size->Get(0)->IntegerValue();
-	result.height = size->Get(1)->IntegerValue();
-
-	return &result;
+  return &result;
 }
 
-
-NAN_METHOD(Matrix::Resize){
+NAN_METHOD(Matrix::Resize) {
   NanScope();
 
   int x = args[0]->Uint32Value();
   int y = args[1]->Uint32Value();
   /*
-    CV_INTER_NN        =0,
-    CV_INTER_LINEAR    =1,
-    CV_INTER_CUBIC     =2,
-    CV_INTER_AREA      =3,
-    CV_INTER_LANCZOS4  =4
-  */
+   CV_INTER_NN        =0,
+   CV_INTER_LINEAR    =1,
+   CV_INTER_CUBIC     =2,
+   CV_INTER_AREA      =3,
+   CV_INTER_LANCZOS4  =4
+   */
   int interpolation = (args.Length() < 3) ? (int)cv::INTER_LINEAR : args[2]->Uint32Value();
 
   Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
@@ -1564,12 +1505,10 @@ NAN_METHOD(Matrix::Resize){
   ~self->mat;
   self->mat = res;
 
-
   NanReturnUndefined();
 }
 
-
-NAN_METHOD(Matrix::Rotate){
+NAN_METHOD(Matrix::Rotate) {
   NanScope();
 
   Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
@@ -1586,27 +1525,29 @@ NAN_METHOD(Matrix::Rotate){
       && (args.Length() == 1);
   if (rightOrStraight) {
     int angle2 = ((int)angle) % 360;
-    if (!angle2) { NanReturnUndefined(); }
-    if (angle2 < 0) { angle2 += 360; }
-	// See if we do right angle rotation, we transpose the matrix:
+    if (!angle2) {NanReturnUndefined();}
+    if (angle2 < 0) {angle2 += 360;}
+    // See if we do right angle rotation, we transpose the matrix:
     if (angle2 % 180) {
-        cv::transpose(self->mat, res);
-        ~self->mat;
-	    self->mat = res;
+      cv::transpose(self->mat, res);
+      ~self->mat;
+      self->mat = res;
     }
     // Now flip the image
-    int mode = -1; // flip around both axes
+    int mode = -1;// flip around both axes
     // If counterclockwise, flip around the x-axis
-    if (angle2 == 90) { mode = 0; }
+    if (angle2 == 90) {mode = 0;}
     // If clockwise, flip around the y-axis
-    if (angle2 == 270) { mode = 1; }
+    if (angle2 == 270) {mode = 1;}
     cv::flip(self->mat, self->mat, mode);
     NanReturnUndefined();
   }
-  //-------------
 
-  int x = args[1]->IsUndefined() ? round(self->mat.size().width / 2) : args[1]->Uint32Value();
-  int y = args[1]->IsUndefined() ? round(self->mat.size().height / 2) : args[2]->Uint32Value();
+  //-------------
+  int x = args[1]->IsUndefined() ? round(self->mat.size().width / 2) :
+      args[1]->Uint32Value();
+  int y = args[1]->IsUndefined() ? round(self->mat.size().height / 2) :
+      args[2]->Uint32Value();
 
   cv::Point center = cv::Point(x,y);
   rotMatrix = getRotationMatrix2D(center, angle, 1.0);
@@ -1618,48 +1559,47 @@ NAN_METHOD(Matrix::Rotate){
   NanReturnUndefined();
 }
 
-NAN_METHOD(Matrix::PyrDown){
-	SETUP_FUNCTION(Matrix)
+NAN_METHOD(Matrix::PyrDown) {
+  SETUP_FUNCTION(Matrix)
 
   cv::pyrDown(self->mat, self->mat);
   NanReturnUndefined();
 }
 
-NAN_METHOD(Matrix::PyrUp){
-	SETUP_FUNCTION(Matrix)
+NAN_METHOD(Matrix::PyrUp) {
+  SETUP_FUNCTION(Matrix)
 
   cv::pyrUp(self->mat, self->mat);
   NanReturnUndefined();
 }
 
 NAN_METHOD(Matrix::inRange) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-	/*if(self->mat.channels() != 3)
-		NanThrowError(String::New("Image is no 3-channel"));*/
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  /*if (self->mat.channels() != 3)
+   NanThrowError(String::New("Image is no 3-channel"));*/
 
-	if(args[0]->IsArray() && args[1]->IsArray()) {
-		Local<Object> args_lowerb = args[0]->ToObject();
-		Local<Object> args_upperb = args[1]->ToObject();
+  if (args[0]->IsArray() && args[1]->IsArray()) {
+    Local<Object> args_lowerb = args[0]->ToObject();
+    Local<Object> args_upperb = args[1]->ToObject();
 
-		cv::Scalar lowerb(0, 0, 0);
-		cv::Scalar upperb(0, 0, 0);
+    cv::Scalar lowerb(0, 0, 0);
+    cv::Scalar upperb(0, 0, 0);
 
-		lowerb = setColor(args_lowerb);
-		upperb = setColor(args_upperb);
+    lowerb = setColor(args_lowerb);
+    upperb = setColor(args_upperb);
 
-		cv::Mat mask;
-		cv::inRange(self->mat, lowerb, upperb, mask);
-		mask.copyTo(self->mat);
-	}
+    cv::Mat mask;
+    cv::inRange(self->mat, lowerb, upperb, mask);
+    mask.copyTo(self->mat);
+  }
 
-
-	NanReturnNull();
+  NanReturnNull();
 }
 
 NAN_METHOD(Matrix::AdjustROI) {
-	SETUP_FUNCTION(Matrix)
+  SETUP_FUNCTION(Matrix)
   int dtop = args[0]->Uint32Value();
   int dbottom = args[1]->Uint32Value();
   int dleft = args[2]->Uint32Value();
@@ -1668,101 +1608,100 @@ NAN_METHOD(Matrix::AdjustROI) {
   self->mat.adjustROI(dtop, dbottom, dleft, dright);
 
   NanReturnNull();
-
 }
 
 NAN_METHOD(Matrix::LocateROI) {
-	SETUP_FUNCTION(Matrix)
+  SETUP_FUNCTION(Matrix)
 
   cv::Size wholeSize;
   cv::Point ofs;
 
   self->mat.locateROI(wholeSize, ofs);
 
-	v8::Local<v8::Array> arr = NanNew<Array>(4);
-	arr->Set(0, NanNew<Number>(wholeSize.width));
-	arr->Set(1, NanNew<Number>(wholeSize.height));
-	arr->Set(2, NanNew<Number>(ofs.x));
-	arr->Set(3, NanNew<Number>(ofs.y));
+  v8::Local < v8::Array > arr = NanNew<Array>(4);
+  arr->Set(0, NanNew<Number>(wholeSize.width));
+  arr->Set(1, NanNew<Number>(wholeSize.height));
+  arr->Set(2, NanNew<Number>(ofs.x));
+  arr->Set(3, NanNew<Number>(ofs.y));
 
-	NanReturnValue(arr);
+  NanReturnValue(arr);
 }
 
-
-
 NAN_METHOD(Matrix::Threshold) {
-	SETUP_FUNCTION(Matrix)
+  SETUP_FUNCTION(Matrix)
 
-	double threshold = args[0]->NumberValue();
-	double maxVal = args[1]->NumberValue();
+  double threshold = args[0]->NumberValue();
+  double maxVal = args[1]->NumberValue();
 
   int typ = cv::THRESH_BINARY;
-	if (args.Length() == 3){
-//    typ = args[2]->IntegerValue();
+  if (args.Length() == 3) {
+    //    typ = args[2]->IntegerValue();
     NanAsciiString typstr(args[2]);
-    if (strcmp(*typstr, "Binary") == 0){
-      typ=0;
+    if (strcmp(*typstr, "Binary") == 0) {
+      typ = 0;
     }
-    if (strcmp(*typstr, "Binary Inverted") == 0){
-      typ=1;
+    if (strcmp(*typstr, "Binary Inverted") == 0) {
+      typ = 1;
     }
-    if (strcmp(*typstr, "Threshold Truncated") == 0){
-      typ=2;
+    if (strcmp(*typstr, "Threshold Truncated") == 0) {
+      typ = 2;
     }
-    if (strcmp(*typstr, "Threshold to Zero") == 0){
-      typ=3;
+    if (strcmp(*typstr, "Threshold to Zero") == 0) {
+      typ = 3;
     }
-    if (strcmp(*typstr, "Threshold to Zero Inverted") == 0){
-      typ=4;
+    if (strcmp(*typstr, "Threshold to Zero Inverted") == 0) {
+      typ = 4;
     }
   }
 
-
-  Local<Object> img_to_return = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-	Matrix *img = ObjectWrap::Unwrap<Matrix>(img_to_return);
-	self->mat.copyTo(img->mat);
+  Local < Object > img_to_return =
+      NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+  Matrix *img = ObjectWrap::Unwrap<Matrix>(img_to_return);
+  self->mat.copyTo(img->mat);
 
   cv::threshold(self->mat, img->mat, threshold, maxVal, typ);
 
-	NanReturnValue(img_to_return);
+  NanReturnValue(img_to_return);
 }
 
 NAN_METHOD(Matrix::AdaptiveThreshold) {
-	SETUP_FUNCTION(Matrix)
+  SETUP_FUNCTION(Matrix)
 
-	double maxVal = args[0]->NumberValue();
+  double maxVal = args[0]->NumberValue();
   double adaptiveMethod = args[1]->NumberValue();
   double thresholdType = args[2]->NumberValue();
   double blockSize = args[3]->NumberValue();
   double C = args[4]->NumberValue();
 
-  Local<Object> img_to_return = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+  Local < Object > img_to_return =
+      NanNew(Matrix::constructor)->GetFunction()->NewInstance();
   Matrix *img = ObjectWrap::Unwrap<Matrix>(img_to_return);
   self->mat.copyTo(img->mat);
 
-  cv::adaptiveThreshold(self->mat, img->mat, maxVal, adaptiveMethod, thresholdType, blockSize, C);
+  cv::adaptiveThreshold(self->mat, img->mat, maxVal, adaptiveMethod,
+      thresholdType, blockSize, C);
 
   NanReturnValue(img_to_return);
 }
 
 NAN_METHOD(Matrix::MeanStdDev) {
-	NanScope();
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
 
   Local<Object> mean = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-	Matrix *m_mean = ObjectWrap::Unwrap<Matrix>(mean);
-	Local<Object> stddev = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-	Matrix *m_stddev = ObjectWrap::Unwrap<Matrix>(stddev);
+  Matrix *m_mean = ObjectWrap::Unwrap<Matrix>(mean);
+  Local<Object> stddev = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+  Matrix *m_stddev = ObjectWrap::Unwrap<Matrix>(stddev);
 
-	cv::meanStdDev(self->mat, m_mean->mat, m_stddev->mat);
+  cv::meanStdDev(self->mat, m_mean->mat, m_stddev->mat);
 
-	Local<Object> data = NanNew<Object>();
-	data->Set(NanNew<String>("mean"), mean);
-	data->Set(NanNew<String>("stddev"), stddev);
-	NanReturnValue(data);
+  Local<Object> data = NanNew<Object>();
+  data->Set(NanNew<String>("mean"), mean);
+  data->Set(NanNew<String>("stddev"), stddev);
+
+  NanReturnValue(data);
 }
-
 
 // @author SergeMv
 // Copies our (small) image into a ROI of another (big) image
@@ -1793,8 +1732,6 @@ NAN_METHOD(Matrix::CopyTo) {
   NanReturnUndefined();
 }
 
-
-
 // @author SergeMv
 // Does in-place color transformation
 // img.cvtColor('CV_BGR2YCrCb');
@@ -1808,41 +1745,40 @@ NAN_METHOD(Matrix::CvtColor) {
   const char * sTransform = (const char *) str2.c_str();
   int iTransform;
   //
-  if (!strcmp(sTransform, "CV_BGR2GRAY")) { iTransform = CV_BGR2GRAY; }
-  else if (!strcmp(sTransform, "CV_GRAY2BGR")) { iTransform = CV_GRAY2BGR; }
+  if (!strcmp(sTransform, "CV_BGR2GRAY")) {iTransform = CV_BGR2GRAY;}
+  else if (!strcmp(sTransform, "CV_GRAY2BGR")) {iTransform = CV_GRAY2BGR;}
   //
-  else if (!strcmp(sTransform, "CV_BGR2XYZ")) { iTransform = CV_BGR2XYZ; }
-  else if (!strcmp(sTransform, "CV_XYZ2BGR")) { iTransform = CV_XYZ2BGR; }
+  else if (!strcmp(sTransform, "CV_BGR2XYZ")) {iTransform = CV_BGR2XYZ;}
+  else if (!strcmp(sTransform, "CV_XYZ2BGR")) {iTransform = CV_XYZ2BGR;}
   //
-  else if (!strcmp(sTransform, "CV_BGR2YCrCb")) { iTransform = CV_BGR2YCrCb; }
-  else if (!strcmp(sTransform, "CV_YCrCb2BGR")) { iTransform = CV_YCrCb2BGR; }
+  else if (!strcmp(sTransform, "CV_BGR2YCrCb")) {iTransform = CV_BGR2YCrCb;}
+  else if (!strcmp(sTransform, "CV_YCrCb2BGR")) {iTransform = CV_YCrCb2BGR;}
   //
-  else if (!strcmp(sTransform, "CV_BGR2HSV")) { iTransform = CV_BGR2HSV; }
-  else if (!strcmp(sTransform, "CV_HSV2BGR")) { iTransform = CV_HSV2BGR; }
+  else if (!strcmp(sTransform, "CV_BGR2HSV")) {iTransform = CV_BGR2HSV;}
+  else if (!strcmp(sTransform, "CV_HSV2BGR")) {iTransform = CV_HSV2BGR;}
   //
-  else if (!strcmp(sTransform, "CV_BGR2HLS")) { iTransform = CV_BGR2HLS; }
-  else if (!strcmp(sTransform, "CV_HLS2BGR")) { iTransform = CV_HLS2BGR; }
+  else if (!strcmp(sTransform, "CV_BGR2HLS")) {iTransform = CV_BGR2HLS;}
+  else if (!strcmp(sTransform, "CV_HLS2BGR")) {iTransform = CV_HLS2BGR;}
   //
-  else if (!strcmp(sTransform, "CV_BGR2Lab")) { iTransform = CV_BGR2Lab; }
-  else if (!strcmp(sTransform, "CV_Lab2BGR")) { iTransform = CV_Lab2BGR; }
+  else if (!strcmp(sTransform, "CV_BGR2Lab")) {iTransform = CV_BGR2Lab;}
+  else if (!strcmp(sTransform, "CV_Lab2BGR")) {iTransform = CV_Lab2BGR;}
   //
-  else if (!strcmp(sTransform, "CV_BGR2Luv")) { iTransform = CV_BGR2Luv; }
-  else if (!strcmp(sTransform, "CV_Luv2BGR")) { iTransform = CV_Luv2BGR; }
+  else if (!strcmp(sTransform, "CV_BGR2Luv")) {iTransform = CV_BGR2Luv;}
+  else if (!strcmp(sTransform, "CV_Luv2BGR")) {iTransform = CV_Luv2BGR;}
   //
-  else if (!strcmp(sTransform, "CV_BayerBG2BGR")) { iTransform = CV_BayerBG2BGR; }
-  else if (!strcmp(sTransform, "CV_BayerGB2BGR")) { iTransform = CV_BayerGB2BGR; }
-  else if (!strcmp(sTransform, "CV_BayerRG2BGR")) { iTransform = CV_BayerRG2BGR; }
-  else if (!strcmp(sTransform, "CV_BayerGR2BGR")) { iTransform = CV_BayerGR2BGR; }
+  else if (!strcmp(sTransform, "CV_BayerBG2BGR")) {iTransform = CV_BayerBG2BGR;}
+  else if (!strcmp(sTransform, "CV_BayerGB2BGR")) {iTransform = CV_BayerGB2BGR;}
+  else if (!strcmp(sTransform, "CV_BayerRG2BGR")) {iTransform = CV_BayerRG2BGR;}
+  else if (!strcmp(sTransform, "CV_BayerGR2BGR")) {iTransform = CV_BayerGR2BGR;}
   else {
-      iTransform = 0; // to avoid compiler warning
-      NanThrowTypeError("Conversion code is unsupported");
+    iTransform = 0;  // to avoid compiler warning
+    NanThrowTypeError("Conversion code is unsupported");
   }
 
   cv::cvtColor(self->mat, self->mat, iTransform);
 
   NanReturnUndefined();
 }
-
 
 // @author SergeMv
 // arrChannels = img.split();
@@ -1863,10 +1799,11 @@ NAN_METHOD(Matrix::Split) {
   size = channels.size();
   v8::Local<v8::Array> arrChannels = NanNew<Array>(size);
   for (unsigned int i = 0; i < size; i++) {
-      Local<Object> matObject = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-      Matrix * m = ObjectWrap::Unwrap<Matrix>(matObject);
-      m->mat = channels[i];
-      arrChannels->Set(i, matObject);
+    Local<Object> matObject =
+        NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+    Matrix * m = ObjectWrap::Unwrap<Matrix>(matObject);
+    m->mat = channels[i];
+    arrChannels->Set(i, matObject);
   }
 
   NanReturnValue(arrChannels);
@@ -1878,23 +1815,21 @@ NAN_METHOD(Matrix::Merge) {
   NanScope();
 
   Matrix * self = ObjectWrap::Unwrap<Matrix>(args.This());
-
   if (!args[0]->IsArray()) {
-      NanThrowTypeError("The argument must be an array");
+    NanThrowTypeError("The argument must be an array");
   }
   v8::Handle<v8::Array> jsChannels = v8::Handle<v8::Array>::Cast(args[0]);
 
   unsigned int L = jsChannels->Length();
   vector<cv::Mat> vChannels(L);
   for (unsigned int i = 0; i < L; i++) {
-       Matrix * matObject = ObjectWrap::Unwrap<Matrix>(jsChannels->Get(i)->ToObject());
-       vChannels[i] = matObject->mat;
+    Matrix * matObject = ObjectWrap::Unwrap<Matrix>(jsChannels->Get(i)->ToObject());
+    vChannels[i] = matObject->mat;
   }
   cv::merge(vChannels, self->mat);
 
   NanReturnUndefined();
 }
-
 
 // @author SergeMv
 // Equalizes histogram
@@ -1908,47 +1843,46 @@ NAN_METHOD(Matrix::EqualizeHist) {
   NanReturnUndefined();
 }
 
-NAN_METHOD(Matrix::FloodFill){
-	SETUP_FUNCTION(Matrix)
-	//obj->Get(NanNew<String>("x"))
-	//int cv::floodFill(cv::InputOutputArray, cv::Point, cv::Scalar, cv::Rect*, cv::Scalar, cv::Scalar, int)
+NAN_METHOD(Matrix::FloodFill) {
+  SETUP_FUNCTION(Matrix)
+  // obj->Get(NanNew<String>("x"))
+  // int cv::floodFill(cv::InputOutputArray, cv::Point, cv::Scalar, cv::Rect*, cv::Scalar, cv::Scalar, int)
 
+  /*  mat.floodFill( {seedPoint: [1,1] ,
+        newColor: [255,0,0] ,
+        rect:[[0,2],[30,40]] ,
+        loDiff : [8,90,60],
+        upDiff:[10,100,70]
+      }); */
 
-	/*	mat.floodFill( { seedPoint: [1,1]   ,
-		      newColor: [255,0,0] ,
-		      rect:[[0,2],[30,40]] ,
-		      loDiff : [8,90,60],
-		      upDiff:[10,100,70]
-	} );*/
+  if (args.Length() < 1 || !args[0]->IsObject()) {
+    // error
+  }
 
+  Local < Object > obj = args[0]->ToObject();
+  cv::Rect rect;
 
-	if(args.Length() < 1 || !args[0]->IsObject()) {
-		//error
-	}
+  int ret = cv::floodFill(self->mat,
+      setPoint(obj->Get(NanNew<String>("seedPoint"))->ToObject()),
+      setColor(obj->Get(NanNew<String>("newColor"))->ToObject()),
+      obj->Get(NanNew<String>("rect"))->IsUndefined() ?
+          0 : setRect(obj->Get(NanNew<String>("rect"))->ToObject(), rect),
+      setColor(obj->Get(NanNew<String>("loDiff"))->ToObject()),
+      setColor(obj->Get(NanNew<String>("upDiff"))->ToObject()), 4);
 
-
-	Local<Object> obj = args[0]->ToObject();
-	cv::Rect rect;
-
-	int  ret = cv::floodFill(self->mat, setPoint(obj->Get(NanNew<String>("seedPoint"))->ToObject())
-			, setColor(obj->Get(NanNew<String>("newColor"))->ToObject())
-			, obj->Get(NanNew<String>("rect"))->IsUndefined() ? 0 : setRect(obj->Get(NanNew<String>("rect"))->ToObject(), rect)
-			, setColor(obj->Get(NanNew<String>("loDiff"))->ToObject())
-			, setColor(obj->Get(NanNew<String>("upDiff"))->ToObject())
-			, 4 );
-
-
-	NanReturnValue(NanNew<Number>( ret ));
+  NanReturnValue(NanNew<Number>(ret));
 }
 
 // @author olfox
 // Returns an array of the most probable positions
 // Usage: output = input.templateMatches(min_probability, max_probability, limit, ascending, min_x_distance, min_y_distance);
-NAN_METHOD(Matrix::TemplateMatches){
-	SETUP_FUNCTION(Matrix)
+NAN_METHOD(Matrix::TemplateMatches) {
+  SETUP_FUNCTION(Matrix)
 
-  bool filter_min_probability = (args.Length() >= 1) ? args[0]->IsNumber() : false;
-  bool filter_max_probability = (args.Length() >= 2) ? args[1]->IsNumber() : false;
+  bool filter_min_probability =
+      (args.Length() >= 1) ? args[0]->IsNumber() : false;
+  bool filter_max_probability =
+      (args.Length() >= 2) ? args[1]->IsNumber() : false;
   double min_probability = filter_min_probability ? args[0]->NumberValue() : 0;
   double max_probability = filter_max_probability ? args[1]->NumberValue() : 0;
   int limit = (args.Length() >= 3) ? args[2]->IntegerValue() : 0;
@@ -1958,31 +1892,41 @@ NAN_METHOD(Matrix::TemplateMatches){
 
   cv::Mat_<int> indices;
 
-  if (ascending)
-    cv::sortIdx(self->mat.reshape(0,1), indices, CV_SORT_ASCENDING + CV_SORT_EVERY_ROW);
-  else
-    cv::sortIdx(self->mat.reshape(0,1), indices, CV_SORT_DESCENDING + CV_SORT_EVERY_ROW);
+  if (ascending) {
+    cv::sortIdx(self->mat.reshape(0, 1), indices,
+    CV_SORT_ASCENDING + CV_SORT_EVERY_ROW);
+  } else {
+    cv::sortIdx(self->mat.reshape(0, 1), indices,
+    CV_SORT_DESCENDING + CV_SORT_EVERY_ROW);
+  }
 
   cv::Mat hit_mask = cv::Mat::zeros(self->mat.size(), CV_64F);
-  v8::Local<v8::Array> probabilites_array = NanNew<v8::Array>(limit);
+  v8::Local < v8::Array > probabilites_array = NanNew<v8::Array>(limit);
 
   cv::Mat_<float>::const_iterator begin = self->mat.begin<float>();
   cv::Mat_<int>::const_iterator it = indices.begin();
   cv::Mat_<int>::const_iterator end = indices.end();
   int index = 0;
+
   for (; (limit == 0 || index < limit) && it != end; ++it) {
     cv::Point pt = (begin + *it).pos();
 
     float probability = self->mat.at<float>(pt.y, pt.x);
 
     if (filter_min_probability && probability < min_probability) {
-      if (ascending) continue;
-      else break;
+      if (ascending) {
+        continue;
+      }
+      else {
+        break;
+      }
     }
 
     if (filter_max_probability && probability > max_probability) {
-      if (ascending) break;
-      else continue;
+      if (ascending)
+        break;
+      else
+        continue;
     }
 
     if (min_x_distance != 0 || min_y_distance != 0) {
@@ -1991,14 +1935,22 @@ NAN_METHOD(Matrix::TemplateMatches){
       cv::Size maxSize = hit_mask.size();
       int max_x = maxSize.width - 1;
       int max_y = maxSize.height - 1;
-      cv::Point top_left = cv::Point(max(0, pt.x - min_x_distance), max(0, pt.y - min_y_distance));
-      cv::Point top_right = cv::Point(min(max_x, pt.x + min_x_distance), max(0, pt.y - min_y_distance));
-      cv::Point bottom_left = cv::Point(max(0, pt.x - min_x_distance), min(max_y, pt.y + min_y_distance));
-      cv::Point bottom_right = cv::Point(min(max_x, pt.x + min_x_distance), min(max_y, pt.y + min_y_distance));
-      if (hit_mask.at<double>(top_left.y, top_left.x) > 0) continue;
-      if (hit_mask.at<double>(top_right.y, top_right.x) > 0) continue;
-      if (hit_mask.at<double>(bottom_left.y, bottom_left.x) > 0) continue;
-      if (hit_mask.at<double>(bottom_right.y, bottom_right.x) > 0) continue;
+      cv::Point top_left = cv::Point(max(0, pt.x - min_x_distance),
+          max(0, pt.y - min_y_distance));
+      cv::Point top_right = cv::Point(min(max_x, pt.x + min_x_distance),
+          max(0, pt.y - min_y_distance));
+      cv::Point bottom_left = cv::Point(max(0, pt.x - min_x_distance),
+          min(max_y, pt.y + min_y_distance));
+      cv::Point bottom_right = cv::Point(min(max_x, pt.x + min_x_distance),
+          min(max_y, pt.y + min_y_distance));
+      if (hit_mask.at<double>(top_left.y, top_left.x) > 0)
+        continue;
+      if (hit_mask.at<double>(top_right.y, top_right.x) > 0)
+        continue;
+      if (hit_mask.at<double>(bottom_left.y, bottom_left.x) > 0)
+        continue;
+      if (hit_mask.at<double>(bottom_right.y, bottom_right.x) > 0)
+        continue;
       cv::Scalar color(255.0);
       cv::rectangle(hit_mask, top_left, bottom_right, color, CV_FILLED);
     }
@@ -2007,7 +1959,7 @@ NAN_METHOD(Matrix::TemplateMatches){
     Local<Value> y_value = NanNew<Number>(pt.y);
     Local<Value> probability_value = NanNew<Number>(probability);
 
-    Local<Object> probability_object = NanNew<Object>();
+    Local < Object > probability_object = NanNew<Object>();
     probability_object->Set(NanNew<String>("x"), x_value);
     probability_object->Set(NanNew<String>("y"), y_value);
     probability_object->Set(NanNew<String>("probability"), probability_value);
@@ -2039,16 +1991,15 @@ NAN_METHOD(Matrix::MatchTemplate) {
   m_out->mat.create(cols, rows, CV_32FC1);
 
   /*
-    TM_SQDIFF        =0
-    TM_SQDIFF_NORMED =1
-    TM_CCORR         =2
-    TM_CCORR_NORMED  =3
-    TM_CCOEFF        =4
-    TM_CCOEFF_NORMED =5
-  */
+   TM_SQDIFF        =0
+   TM_SQDIFF_NORMED =1
+   TM_CCORR         =2
+   TM_CCORR_NORMED  =3
+   TM_CCOEFF        =4
+   TM_CCOEFF_NORMED =5
+   */
 
   int method = (args.Length() < 2) ? (int)cv::TM_CCORR_NORMED : args[1]->Uint32Value();
-
   cv::matchTemplate(self->mat, templ, m_out->mat, method);
 
   NanReturnValue(out);
@@ -2060,9 +2011,7 @@ NAN_METHOD(Matrix::MinMaxLoc) {
   NanScope();
 
   Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-
   double minVal; double maxVal; cv::Point minLoc; cv::Point maxLoc;
-
   cv::minMaxLoc(self->mat, &minVal, &maxVal, &minLoc, &maxLoc, cv::Mat() );
 
   Local<Value> v_minVal = NanNew<Number>(minVal);
@@ -2090,16 +2039,13 @@ NAN_METHOD(Matrix::MinMaxLoc) {
   NanReturnValue(result);
 }
 
-
 // @author ytham
 // Pushes some matrix (argument) the back of a matrix (self)
 NAN_METHOD(Matrix::PushBack) {
   NanScope();
 
   Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-
   Matrix *m_input = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-
   self->mat.push_back(m_input->mat);
 
   NanReturnValue(args.This());
@@ -2109,8 +2055,8 @@ NAN_METHOD(Matrix::PutText) {
   NanScope();
 
   Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
-  NanAsciiString textString(args[0]);//FIXME: might cause issues, see here https://github.com/rvagg/nan/pull/152
-  char *text = *textString; //(char *) malloc(textString.length() + 1);
+  NanAsciiString textString(args[0]);  //FIXME: might cause issues, see here https://github.com/rvagg/nan/pull/152
+  char *text = *textString;//(char *) malloc(textString.length() + 1);
   //strcpy(text, *textString);
 
   int x = args[1]->IntegerValue();
@@ -2121,19 +2067,19 @@ NAN_METHOD(Matrix::PutText) {
   //strcpy(font, *fontString);
   int constFont = cv::FONT_HERSHEY_SIMPLEX;
 
-  if (!strcmp(font, "HERSEY_SIMPLEX")) { constFont = cv::FONT_HERSHEY_SIMPLEX; }
-  else if (!strcmp(font, "HERSEY_PLAIN")) { constFont = cv::FONT_HERSHEY_PLAIN; }
-  else if (!strcmp(font, "HERSEY_DUPLEX")) { constFont = cv::FONT_HERSHEY_DUPLEX; }
-  else if (!strcmp(font, "HERSEY_COMPLEX")) { constFont = cv::FONT_HERSHEY_COMPLEX; }
-  else if (!strcmp(font, "HERSEY_TRIPLEX")) { constFont = cv::FONT_HERSHEY_TRIPLEX; }
-  else if (!strcmp(font, "HERSEY_COMPLEX_SMALL")) { constFont = cv::FONT_HERSHEY_COMPLEX_SMALL; }
-  else if (!strcmp(font, "HERSEY_SCRIPT_SIMPLEX")) { constFont = cv::FONT_HERSHEY_SCRIPT_SIMPLEX; }
-  else if (!strcmp(font, "HERSEY_SCRIPT_COMPLEX")) { constFont = cv::FONT_HERSHEY_SCRIPT_COMPLEX; }
-  else if (!strcmp(font, "HERSEY_SCRIPT_SIMPLEX")) { constFont = cv::FONT_HERSHEY_SCRIPT_SIMPLEX; }
+  if (!strcmp(font, "HERSEY_SIMPLEX")) {constFont = cv::FONT_HERSHEY_SIMPLEX;}
+  else if (!strcmp(font, "HERSEY_PLAIN")) {constFont = cv::FONT_HERSHEY_PLAIN;}
+  else if (!strcmp(font, "HERSEY_DUPLEX")) {constFont = cv::FONT_HERSHEY_DUPLEX;}
+  else if (!strcmp(font, "HERSEY_COMPLEX")) {constFont = cv::FONT_HERSHEY_COMPLEX;}
+  else if (!strcmp(font, "HERSEY_TRIPLEX")) {constFont = cv::FONT_HERSHEY_TRIPLEX;}
+  else if (!strcmp(font, "HERSEY_COMPLEX_SMALL")) {constFont = cv::FONT_HERSHEY_COMPLEX_SMALL;}
+  else if (!strcmp(font, "HERSEY_SCRIPT_SIMPLEX")) {constFont = cv::FONT_HERSHEY_SCRIPT_SIMPLEX;}
+  else if (!strcmp(font, "HERSEY_SCRIPT_COMPLEX")) {constFont = cv::FONT_HERSHEY_SCRIPT_COMPLEX;}
+  else if (!strcmp(font, "HERSEY_SCRIPT_SIMPLEX")) {constFont = cv::FONT_HERSHEY_SCRIPT_SIMPLEX;}
 
   cv::Scalar color(0, 0, 255);
 
-  if(args[4]->IsArray()) {
+  if (args[4]->IsArray()) {
     Local<Object> objColor = args[4]->ToObject();
     color = setColor(objColor);
   }
@@ -2146,7 +2092,6 @@ NAN_METHOD(Matrix::PutText) {
   NanReturnUndefined();
 }
 
-
 NAN_METHOD(Matrix::GetPerspectiveTransform) {
   NanScope();
 
@@ -2157,8 +2102,8 @@ NAN_METHOD(Matrix::GetPerspectiveTransform) {
   std::vector<cv::Point2f> src_corners(4);
   std::vector<cv::Point2f> tgt_corners(4);
   for (unsigned int i = 0; i < 4; i++) {
-      src_corners[i] = cvPoint(srcArray->Get(i*2)->IntegerValue(),srcArray->Get(i*2+1)->IntegerValue());
-      tgt_corners[i] = cvPoint(tgtArray->Get(i*2)->IntegerValue(),tgtArray->Get(i*2+1)->IntegerValue());
+    src_corners[i] = cvPoint(srcArray->Get(i*2)->IntegerValue(),srcArray->Get(i*2+1)->IntegerValue());
+    tgt_corners[i] = cvPoint(tgtArray->Get(i*2)->IntegerValue(),tgtArray->Get(i*2+1)->IntegerValue());
   }
 
   Local<Object> xfrm = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
@@ -2167,7 +2112,6 @@ NAN_METHOD(Matrix::GetPerspectiveTransform) {
 
   NanReturnValue(xfrm);
 }
-
 
 NAN_METHOD(Matrix::WarpPerspective) {
   SETUP_FUNCTION(Matrix)
@@ -2182,14 +2126,15 @@ NAN_METHOD(Matrix::WarpPerspective) {
 
   cv::Scalar borderColor(0, 0, 255);
 
-  if(args[3]->IsArray()) {
-      Local<Object> objColor = args[3]->ToObject();
-      borderColor = setColor(objColor);
+  if (args[3]->IsArray()) {
+    Local < Object > objColor = args[3]->ToObject();
+    borderColor = setColor(objColor);
   }
 
   cv::Mat res = cv::Mat(width, height, CV_32FC3);
 
-  cv::warpPerspective(self->mat, res, xfrm->mat, cv::Size(width, height), flags, borderMode, borderColor);
+  cv::warpPerspective(self->mat, res, xfrm->mat, cv::Size(width, height), flags,
+      borderMode, borderColor);
 
   ~self->mat;
   self->mat = res;
@@ -2205,17 +2150,16 @@ NAN_METHOD(Matrix::CopyWithMask) {
   // param 1 - mask. same size as src and dest
   Matrix *mask = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
 
-  self->mat.copyTo(dest->mat,mask->mat);
+  self->mat.copyTo(dest->mat, mask->mat);
 
   NanReturnUndefined();
 }
-
 
 NAN_METHOD(Matrix::SetWithMask) {
   SETUP_FUNCTION(Matrix)
 
   // param 0 - target value:
-  Local<Object> valArray = args[0]->ToObject();
+  Local < Object > valArray = args[0]->ToObject();
   cv::Scalar newvals;
   newvals.val[0] = valArray->Get(0)->NumberValue();
   newvals.val[1] = valArray->Get(1)->NumberValue();
@@ -2224,7 +2168,7 @@ NAN_METHOD(Matrix::SetWithMask) {
   // param 1 - mask. same size as src and dest
   Matrix *mask = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
 
-  self->mat.setTo(newvals,mask->mat);
+  self->mat.setTo(newvals, mask->mat);
 
   NanReturnUndefined();
 }
@@ -2236,15 +2180,15 @@ NAN_METHOD(Matrix::MeanWithMask) {
   Matrix *mask = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
 
   cv::Scalar means = cv::mean(self->mat, mask->mat);
-  v8::Local<v8::Array> arr = NanNew<Array>(3);
-  arr->Set(0, NanNew<Number>( means[0] ));
-  arr->Set(1, NanNew<Number>( means[1] ));
-  arr->Set(2, NanNew<Number>( means[2] ));
+  v8::Local < v8::Array > arr = NanNew<Array>(3);
+  arr->Set(0, NanNew<Number>(means[0]));
+  arr->Set(1, NanNew<Number>(means[1]));
+  arr->Set(2, NanNew<Number>(means[2]));
 
   NanReturnValue(arr);
 }
 
-NAN_METHOD(Matrix::Shift){
+NAN_METHOD(Matrix::Shift) {
   SETUP_FUNCTION(Matrix)
 
   cv::Mat res;
@@ -2255,21 +2199,30 @@ NAN_METHOD(Matrix::Shift){
   // get the integer values of args
   cv::Point2i deltai(ceil(tx), ceil(ty));
 
-  int fill=cv::BORDER_REPLICATE;
-  cv::Scalar value=cv::Scalar(0,0,0,0);
+  int fill = cv::BORDER_REPLICATE;
+  cv::Scalar value = cv::Scalar(0, 0, 0, 0);
 
   // INTEGER SHIFT
   // first create a border around the parts of the Mat that will be exposed
   int t = 0, b = 0, l = 0, r = 0;
-  if (deltai.x > 0) l =  deltai.x;
-  if (deltai.x < 0) r = -deltai.x;
-  if (deltai.y > 0) t =  deltai.y;
-  if (deltai.y < 0) b = -deltai.y;
+  if (deltai.x > 0) {
+    l = deltai.x;
+  }
+  if (deltai.x < 0) {
+    r = -deltai.x;
+  }
+  if (deltai.y > 0) {
+    t = deltai.y;
+  }
+  if (deltai.y < 0) {
+    b = -deltai.y;
+  }
   cv::Mat padded;
   cv::copyMakeBorder(self->mat, padded, t, b, l, r, fill, value);
 
   // construct the region of interest around the new matrix
-  cv::Rect roi = cv::Rect(std::max(-deltai.x,0),std::max(-deltai.y,0),0,0) + self->mat.size();
+  cv::Rect roi = cv::Rect(std::max(-deltai.x, 0), std::max(-deltai.y, 0), 0, 0)
+      + self->mat.size();
   res = padded(roi);
   ~self->mat;
   self->mat = res;
@@ -2277,13 +2230,11 @@ NAN_METHOD(Matrix::Shift){
   NanReturnUndefined();
 }
 
-NAN_METHOD(Matrix::Release)
-{
-	NanScope();
+NAN_METHOD(Matrix::Release) {
+  NanScope();
 
-	Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  Matrix *self = ObjectWrap::Unwrap<Matrix>(args.This());
+  self->mat.release();
 
-	self->mat.release();
-
-	NanReturnUndefined();
+  NanReturnUndefined();
 }

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -1,153 +1,152 @@
 #include "OpenCV.h"
 
 class Matrix: public node::ObjectWrap {
-  public:
+public:
 
-    cv::Mat mat;
-    static Persistent<FunctionTemplate> constructor;
-    static void Init(Handle<Object> target);
-    static NAN_METHOD(New);
-    Matrix();
-    Matrix(cv::Mat other, cv::Rect roi);
-    Matrix(int rows, int cols);
-    Matrix(int rows, int cols, int type);
-    Matrix(int rows, int cols, int type, Local<Object> scalarObj);
+  cv::Mat mat;
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(New);
+  Matrix();
+  Matrix(cv::Mat other, cv::Rect roi);
+  Matrix(int rows, int cols);
+  Matrix(int rows, int cols, int type);
+  Matrix(int rows, int cols, int type, Local<Object> scalarObj);
 
-    static double DblGet(cv::Mat mat, int i, int j);
+  static double DblGet(cv::Mat mat, int i, int j);
 
-    JSFUNC(Zeros) // factory
-    JSFUNC(Ones) // factory
-    JSFUNC(Eye) // factory
+  JSFUNC(Zeros)  // factory
+  JSFUNC(Ones)  // factory
+  JSFUNC(Eye)  // factory
 
-    JSFUNC(Get) // at
-    JSFUNC(Set)
-    JSFUNC(Put)
+  JSFUNC(Get)  // at
+  JSFUNC(Set)
+  JSFUNC(Put)
 
-    JSFUNC(GetData)
-    JSFUNC(Normalize)
-    JSFUNC(Brightness)
+  JSFUNC(GetData)
+  JSFUNC(Normalize)
+  JSFUNC(Brightness)
 
-    JSFUNC(Row)
-    JSFUNC(PixelRow)
-    JSFUNC(Col)
-    JSFUNC(PixelCol)
+  JSFUNC(Row)
+  JSFUNC(PixelRow)
+  JSFUNC(Col)
+  JSFUNC(PixelCol)
 
-    JSFUNC(Size)
-    JSFUNC(Width)
-    JSFUNC(Height)
-    JSFUNC(Channels)
-    JSFUNC(Clone)
-    JSFUNC(Ellipse)
-    JSFUNC(Rectangle)
-    JSFUNC(Line)
-    JSFUNC(Empty)
-    JSFUNC(FillPoly)
+  JSFUNC(Size)
+  JSFUNC(Width)
+  JSFUNC(Height)
+  JSFUNC(Channels)
+  JSFUNC(Clone)
+  JSFUNC(Ellipse)
+  JSFUNC(Rectangle)
+  JSFUNC(Line)
+  JSFUNC(Empty)
+  JSFUNC(FillPoly)
 
-    JSFUNC(Save)
-    JSFUNC(SaveAsync)
+  JSFUNC(Save)
+  JSFUNC(SaveAsync)
 
-    JSFUNC(ToBuffer)
-    JSFUNC(ToBufferAsync)
+  JSFUNC(ToBuffer)
+  JSFUNC(ToBufferAsync)
 
-    JSFUNC(Resize)
-    JSFUNC(Rotate)
-    JSFUNC(PyrDown)
-    JSFUNC(PyrUp)
+  JSFUNC(Resize)
+  JSFUNC(Rotate)
+  JSFUNC(PyrDown)
+  JSFUNC(PyrUp)
 
-    JSFUNC(ConvertGrayscale)
-    JSFUNC(ConvertHSVscale)
-    JSFUNC(GaussianBlur)
-    JSFUNC(MedianBlur)
-    JSFUNC(BilateralFilter)
-    JSFUNC(Copy)
-    JSFUNC(Flip)
-    JSFUNC(ROI)
-    JSFUNC(Ptr)
-    JSFUNC(AbsDiff)
-    JSFUNC(AddWeighted)
-    JSFUNC(BitwiseXor)
-    JSFUNC(BitwiseNot)
-    JSFUNC(BitwiseAnd)
-    JSFUNC(CountNonZero)
-    //JSFUNC(Split)
-    JSFUNC(Canny)
-    JSFUNC(Dilate)
-    JSFUNC(Erode)
+  JSFUNC(ConvertGrayscale)
+  JSFUNC(ConvertHSVscale)
+  JSFUNC(GaussianBlur)
+  JSFUNC(MedianBlur)
+  JSFUNC(BilateralFilter)
+  JSFUNC(Copy)
+  JSFUNC(Flip)
+  JSFUNC(ROI)
+  JSFUNC(Ptr)
+  JSFUNC(AbsDiff)
+  JSFUNC(AddWeighted)
+  JSFUNC(BitwiseXor)
+  JSFUNC(BitwiseNot)
+  JSFUNC(BitwiseAnd)
+  JSFUNC(CountNonZero)
+  //JSFUNC(Split)
+  JSFUNC(Canny)
+  JSFUNC(Dilate)
+  JSFUNC(Erode)
 
-    JSFUNC(FindContours)
-    JSFUNC(DrawContour)
-    JSFUNC(DrawAllContours)
+  JSFUNC(FindContours)
+  JSFUNC(DrawContour)
+  JSFUNC(DrawAllContours)
 
-    // Feature Detection
-    JSFUNC(GoodFeaturesToTrack)
-    JSFUNC(HoughLinesP)
-    JSFUNC(HoughCircles)
+  // Feature Detection
+  JSFUNC(GoodFeaturesToTrack)
+  JSFUNC(HoughLinesP)
+  JSFUNC(HoughCircles)
 
-    JSFUNC(Crop)
+  JSFUNC(Crop)
 
-    JSFUNC(inRange)
+  JSFUNC(inRange)
 
-    JSFUNC(LocateROI)
-    JSFUNC(AdjustROI)
+  JSFUNC(LocateROI)
+  JSFUNC(AdjustROI)
 
-    JSFUNC(Threshold)
-    JSFUNC(AdaptiveThreshold)
-    JSFUNC(MeanStdDev)
+  JSFUNC(Threshold)
+  JSFUNC(AdaptiveThreshold)
+  JSFUNC(MeanStdDev)
 
-    JSFUNC(CopyTo)
-    JSFUNC(CvtColor)
-    JSFUNC(Split)
-    JSFUNC(Merge)
-    JSFUNC(EqualizeHist)
-    JSFUNC(Pixel)
-    JSFUNC(FloodFill)
+  JSFUNC(CopyTo)
+  JSFUNC(CvtColor)
+  JSFUNC(Split)
+  JSFUNC(Merge)
+  JSFUNC(EqualizeHist)
+  JSFUNC(Pixel)
+  JSFUNC(FloodFill)
 
-    JSFUNC(MatchTemplate)
-    JSFUNC(TemplateMatches)
-    JSFUNC(MinMaxLoc)
+  JSFUNC(MatchTemplate)
+  JSFUNC(TemplateMatches)
+  JSFUNC(MinMaxLoc)
 
-    JSFUNC(PushBack)
+  JSFUNC(PushBack)
 
-    JSFUNC(PutText)
-    JSFUNC(GetPerspectiveTransform)
-    JSFUNC(WarpPerspective)
+  JSFUNC(PutText)
+  JSFUNC(GetPerspectiveTransform)
+  JSFUNC(WarpPerspective)
 
-    JSFUNC(CopyWithMask)
-    JSFUNC(SetWithMask)
-    JSFUNC(MeanWithMask)
-    JSFUNC(Shift)
+  JSFUNC(CopyWithMask)
+  JSFUNC(SetWithMask)
+  JSFUNC(MeanWithMask)
+  JSFUNC(Shift)
 
-    JSFUNC(Release)
-/*
-    static Handle<Value> Val(const Arguments& args);
-    static Handle<Value> RowRange(const Arguments& args);
-    static Handle<Value> ColRange(const Arguments& args);
-    static Handle<Value> Diag(const Arguments& args);
-    static Handle<Value> Clone(const Arguments& args);
-    static Handle<Value> CopyTo(const Arguments& args);
-    static Handle<Value> ConvertTo(const Arguments& args);
-    static Handle<Value> AssignTo(const Arguments& args);
-    static Handle<Value> SetTo(const Arguments& args);
-    static Handle<Value> Reshape(const Arguments& args);
-    static Handle<Value> Transpose(const Arguments& args);
-    static Handle<Value> Invert(const Arguments& args);
-    static Handle<Value> Multiply(const Arguments& args);
-    static Handle<Value> Cross(const Arguments& args);
-    static Handle<Value> Dot(const Arguments& args);
-    static Handle<Value> Zeroes(const Arguments& args);
-    static Handle<Value> Ones(const Arguments& args);
-// create, increment, release
-    static Handle<Value> PushBack(const Arguments& args);
-    static Handle<Value> PopBack(const Arguments& args);
-    static Handle<Value> Total(const Arguments& args);
-    static Handle<Value> IsContinous(const Arguments& args);
-    static Handle<Value> Type(const Arguments& args);
-    static Handle<Value> Depth(const Arguments& args);
-    static Handle<Value> Channels(const Arguments& args);
-    static Handle<Value> StepOne(const Arguments& args);
-    static Handle<Value> GetPerspectiveTransform(const Arguments& args);
-    static Handle<Value> WarpPerspective(const Arguments& args);
+  JSFUNC(Release)
+  /*
+   static Handle<Value> Val(const Arguments& args);
+   static Handle<Value> RowRange(const Arguments& args);
+   static Handle<Value> ColRange(const Arguments& args);
+   static Handle<Value> Diag(const Arguments& args);
+   static Handle<Value> Clone(const Arguments& args);
+   static Handle<Value> CopyTo(const Arguments& args);
+   static Handle<Value> ConvertTo(const Arguments& args);
+   static Handle<Value> AssignTo(const Arguments& args);
+   static Handle<Value> SetTo(const Arguments& args);
+   static Handle<Value> Reshape(const Arguments& args);
+   static Handle<Value> Transpose(const Arguments& args);
+   static Handle<Value> Invert(const Arguments& args);
+   static Handle<Value> Multiply(const Arguments& args);
+   static Handle<Value> Cross(const Arguments& args);
+   static Handle<Value> Dot(const Arguments& args);
+   static Handle<Value> Zeroes(const Arguments& args);
+   static Handle<Value> Ones(const Arguments& args);
+   // create, increment, release
+   static Handle<Value> PushBack(const Arguments& args);
+   static Handle<Value> PopBack(const Arguments& args);
+   static Handle<Value> Total(const Arguments& args);
+   static Handle<Value> IsContinous(const Arguments& args);
+   static Handle<Value> Type(const Arguments& args);
+   static Handle<Value> Depth(const Arguments& args);
+   static Handle<Value> Channels(const Arguments& args);
+   static Handle<Value> StepOne(const Arguments& args);
+   static Handle<Value> GetPerspectiveTransform(const Arguments& args);
+   static Handle<Value> WarpPerspective(const Arguments& args);
 
-*/
-
+   */
 };

--- a/src/OpenCV.cc
+++ b/src/OpenCV.cc
@@ -2,8 +2,7 @@
 #include "Matrix.h"
 #include <nan.h>
 
-void
-OpenCV::Init(Handle<Object> target) {
+void OpenCV::Init(Handle<Object> target) {
   NanScope();
 
   // Version string.
@@ -14,25 +13,22 @@ OpenCV::Init(Handle<Object> target) {
   NODE_SET_METHOD(target, "readImage", ReadImage);
 }
 
-
 NAN_METHOD(OpenCV::ReadImage) {
   NanEscapableScope();
 
   REQ_FUN_ARG(1, cb);
 
   Local<Value> argv[2];
-
   argv[0] = NanNull();
 
   Local<Object> im_h = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
   Matrix *img = ObjectWrap::Unwrap<Matrix>(im_h);
   argv[1] = im_h;
 
-  try{
-
+  try {
     cv::Mat mat;
 
-    if (args[0]->IsNumber() && args[1]->IsNumber()){
+    if (args[0]->IsNumber() && args[1]->IsNumber()) {
       int width, height;
 
       width = args[0]->Uint32Value();
@@ -40,31 +36,28 @@ NAN_METHOD(OpenCV::ReadImage) {
       mat = *(new cv::Mat(width, height, CV_64FC1));
 
     } else if (args[0]->IsString()) {
-
       std::string filename = std::string(*NanUtf8String(args[0]->ToString()));
       mat = cv::imread(filename);
 
-    } else if (Buffer::HasInstance(args[0])){
-     	uint8_t *buf = (uint8_t *) Buffer::Data(args[0]->ToObject());
-     	unsigned len = Buffer::Length(args[0]->ToObject());
+    } else if (Buffer::HasInstance(args[0])) {
+      uint8_t *buf = (uint8_t *) Buffer::Data(args[0]->ToObject());
+      unsigned len = Buffer::Length(args[0]->ToObject());
 
-  	 	cv::Mat *mbuf = new cv::Mat(len, 1, CV_64FC1, buf);
+      cv::Mat *mbuf = new cv::Mat(len, 1, CV_64FC1, buf);
       mat = cv::imdecode(*mbuf, -1);
 
-      if (mat.empty()){
+      if (mat.empty()) {
         argv[0] = NanError("Error loading file");
       }
     }
 
     img->mat = mat;
-
-  } catch( cv::Exception& e ){
-      argv[0] = NanError(e.what());
-      argv[1] = NanNull();
+  } catch (cv::Exception& e) {
+    argv[0] = NanError(e.what());
+    argv[1] = NanNull();
   }
 
   TryCatch try_catch;
-
   cb->Call(NanGetCurrentContext()->Global(), 2, argv);
 
   if (try_catch.HasCaught()) {
@@ -72,4 +65,4 @@ NAN_METHOD(OpenCV::ReadImage) {
   }
 
   NanReturnUndefined();
-};
+}

--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -19,7 +19,6 @@ using namespace node;
     return NanThrowTypeError("Argument " #I " must be a function");  \
   Local<Function> VAR = Local<Function>::Cast(args[I]);
 
-
 #define SETUP_FUNCTION(TYP)	\
 	NanScope();		\
 	TYP *self = ObjectWrap::Unwrap<TYP>(args.This());
@@ -30,10 +29,8 @@ using namespace node;
 #define JSTHROW_TYPE(ERR) \
   NanThrowTypeError( ERR );
 
-
 #define JSTHROW(ERR) \
   NanThrowError( ERR );
-
 
 #define INT_FROM_ARGS(NAME, IND) \
   if (args[IND]->IsInt32()){ \
@@ -45,13 +42,11 @@ using namespace node;
     NAME = args[IND]->NumberValue(); \
   }
 
-class OpenCV: public node::ObjectWrap{
-  public:
-    static void Init(Handle<Object> target);
+class OpenCV: public node::ObjectWrap {
+public:
+  static void Init(Handle<Object> target);
 
-    static NAN_METHOD(ReadImage);
+  static NAN_METHOD(ReadImage);
 };
-
-
 
 #endif

--- a/src/Point.cc
+++ b/src/Point.cc
@@ -3,60 +3,61 @@
 
 v8::Persistent<FunctionTemplate> Point::constructor;
 
+void Point::Init(Handle<Object> target) {
+  NanScope();
 
-void
-Point::Init(Handle<Object> target) {
-    NanScope();
+  // Constructor
+  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(Point::New);
+  NanAssignPersistent(constructor, ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(NanNew("Point"));
 
-    // Constructor
-    Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(Point::New);
-    NanAssignPersistent(constructor, ctor);
-    ctor->InstanceTemplate()->SetInternalFieldCount(1);
-    ctor->SetClassName(NanNew("Point"));
-    
-    // Prototype
-    Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
-    proto->SetAccessor(NanNew("x"), GetX, RaiseImmutable);
-    proto->SetAccessor(NanNew("y"), GetY, RaiseImmutable);
-    
-    
-    NODE_SET_PROTOTYPE_METHOD(ctor, "dot", Dot);
+  // Prototype
+  Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
+  proto->SetAccessor(NanNew("x"), GetX, RaiseImmutable);
+  proto->SetAccessor(NanNew("y"), GetY, RaiseImmutable);
 
-    target->Set(NanNew("Point"), ctor->GetFunction());
-};    
+  NODE_SET_PROTOTYPE_METHOD(ctor, "dot", Dot);
+
+  target->Set(NanNew("Point"), ctor->GetFunction());
+};
 
 NAN_METHOD(Point::New) {
   NanScope();
 
-  if (args.This()->InternalFieldCount() == 0)
+  if (args.This()->InternalFieldCount() == 0) {
     return NanThrowTypeError("Cannot Instantiate without new");
+  }
 
   double x = 0, y = 0;
-  if (args[0]->IsNumber()) x = args[0]->NumberValue();
-  if (args[1]->IsNumber()) y = args[1]->NumberValue();
-  Point *pt = new Point(x, y);  
+  if (args[0]->IsNumber()) {
+    x = args[0]->NumberValue();
+  }
+  if (args[1]->IsNumber()) {
+    y = args[1]->NumberValue();
+  }
+  Point *pt = new Point(x, y);
   pt->Wrap(args.This());
   NanReturnValue(args.This());
 }
 
-NAN_GETTER(Point::GetX){ 
+NAN_GETTER(Point::GetX) {
   NanScope();
   Point *pt = ObjectWrap::Unwrap<Point>(args.This());
   NanReturnValue(NanNew<Number>(pt->point.x));
 }
 
-NAN_GETTER(Point::GetY){
+NAN_GETTER(Point::GetY) {
   NanScope();
   Point *pt = ObjectWrap::Unwrap<Point>(args.This());
   NanReturnValue(NanNew<Number>(pt->point.y));
 }
 
-
-NAN_SETTER(Point::RaiseImmutable){
+NAN_SETTER(Point::RaiseImmutable) {
   NanThrowTypeError("Point is immutable");
 }
 
-NAN_METHOD(Point::Dot){
+NAN_METHOD(Point::Dot) {
   NanScope();
   Point *p1 = ObjectWrap::Unwrap<Point>(args.This());
   Point *p2 = ObjectWrap::Unwrap<Point>(args[0]->ToObject());
@@ -65,7 +66,7 @@ NAN_METHOD(Point::Dot){
   NanReturnValue(NanNew<Number>(p1->point.x * p2->point.x + p1->point.y * p2->point.y));
 }
 
-
-Point::Point(double x, double y): ObjectWrap() {
-    point = cvPoint2D32f(x, y); 
+Point::Point(double x, double y) :
+    ObjectWrap() {
+  point = cvPoint2D32f(x, y);
 }

--- a/src/Point.h
+++ b/src/Point.h
@@ -3,17 +3,17 @@
 #include "OpenCV.h"
 
 class Point: public node::ObjectWrap {
-  public:
-      CvPoint2D32f point;
-      static Persistent<FunctionTemplate> constructor;
-      static void Init(Handle<Object> target);
-      static NAN_METHOD(New);
-      Point(double x, double y);      
-      
-      static NAN_GETTER(GetX);
-      static NAN_GETTER(GetY);
-      static NAN_SETTER(RaiseImmutable);
-      
-      static NAN_METHOD(Dot);
+public:
+  CvPoint2D32f point;
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(New);
+  Point(double x, double y);
+
+  static NAN_GETTER(GetX);
+  static NAN_GETTER(GetY);
+  static NAN_SETTER(RaiseImmutable);
+
+  static NAN_METHOD(Dot);
 };
 

--- a/src/Stereo.cc
+++ b/src/Stereo.cc
@@ -6,318 +6,309 @@
 
 v8::Persistent<FunctionTemplate> StereoBM::constructor;
 
-void
-StereoBM::Init(Handle<Object> target) {
-    NanScope();
+void StereoBM::Init(Handle<Object> target) {
+  NanScope();
 
-    Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(StereoBM::New);
-    NanAssignPersistent(constructor, ctor);
-    ctor->InstanceTemplate()->SetInternalFieldCount(1);
-    ctor->SetClassName(NanNew("StereoBM"));
+  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(StereoBM::New);
+  NanAssignPersistent(constructor, ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(NanNew("StereoBM"));
 
-    NODE_SET_PROTOTYPE_METHOD(ctor, "compute", Compute);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "compute", Compute);
 
-    ctor->Set(NanNew<String>("BASIC_PRESET"), NanNew<Integer>((int)cv::StereoBM::BASIC_PRESET));
-    ctor->Set(NanNew<String>("FISH_EYE_PRESET"), NanNew<Integer>((int)cv::StereoBM::FISH_EYE_PRESET));
-    ctor->Set(NanNew<String>("NARROW_PRESET"), NanNew<Integer>((int)cv::StereoBM::NARROW_PRESET));
+  ctor->Set(NanNew<String>("BASIC_PRESET"), NanNew<Integer>((int)cv::StereoBM::BASIC_PRESET));
+  ctor->Set(NanNew<String>("FISH_EYE_PRESET"), NanNew<Integer>((int)cv::StereoBM::FISH_EYE_PRESET));
+  ctor->Set(NanNew<String>("NARROW_PRESET"), NanNew<Integer>((int)cv::StereoBM::NARROW_PRESET));
 
-    target->Set(NanNew("StereoBM"), ctor->GetFunction());
+  target->Set(NanNew("StereoBM"), ctor->GetFunction());
 }
 
 NAN_METHOD(StereoBM::New) {
-    NanScope();
+  NanScope();
 
-    if (args.This()->InternalFieldCount() == 0)
-        NanThrowTypeError("Cannot instantiate without new");
+  if (args.This()->InternalFieldCount() == 0) {
+    NanThrowTypeError("Cannot instantiate without new");
+  }
 
-    StereoBM *stereo;
+  StereoBM *stereo;
 
-    if (args.Length() == 0)
-    {
-        stereo = new StereoBM();
-    }
-    else if (args.Length() == 1)
-    {
-        stereo = new StereoBM(args[0]->IntegerValue()); // preset
-    }
-    else if (args.Length() == 2)
-    {
-        stereo = new StereoBM(args[0]->IntegerValue(), args[1]->IntegerValue()); // preset, disparity search range
-    }
-    else
-    {
-        stereo = new StereoBM(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue()); // preset, disparity search range, sum of absolute differences window size
-    }
+  if (args.Length() == 0) {
+    stereo = new StereoBM();
+  } else if (args.Length() == 1) {
+    // preset
+    stereo = new StereoBM(args[0]->IntegerValue());
+  } else if (args.Length() == 2) {
+    // preset, disparity search range
+    stereo = new StereoBM(args[0]->IntegerValue(), args[1]->IntegerValue());
+  } else {
+    stereo = new StereoBM(args[0]->IntegerValue(), args[1]->IntegerValue(),
+        // preset, disparity search range, sum of absolute differences window size
+        args[2]->IntegerValue());
+  }
 
-    stereo->Wrap(args.Holder());
-    NanReturnValue(args.Holder());
+  stereo->Wrap(args.Holder());
+  NanReturnValue(args.Holder());
 }
 
-StereoBM::StereoBM(int preset, int ndisparities, int SADWindowSize)
-    : ObjectWrap(), stereo(preset, ndisparities, SADWindowSize)
-{
-
+StereoBM::StereoBM(int preset, int ndisparities, int SADWindowSize) :
+    ObjectWrap(),
+    stereo(preset, ndisparities, SADWindowSize) {
 }
 
 // TODO make this async
-NAN_METHOD(StereoBM::Compute)
-{
-    SETUP_FUNCTION(StereoBM)
+NAN_METHOD(StereoBM::Compute) {
+  SETUP_FUNCTION(StereoBM)
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg 0, the 'left' image
-        Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-        cv::Mat left = m0->mat;
+    // Arg 0, the 'left' image
+    Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+    cv::Mat left = m0->mat;
 
-        // Arg 1, the 'right' image
-        Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
-        cv::Mat right = m1->mat;
+    // Arg 1, the 'right' image
+    Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
+    cv::Mat right = m1->mat;
 
-        // Optional 3rd arg, the disparty depth
-        int type = CV_16S;
-        if(args.Length() > 2)
-        {
-            type = args[2]->IntegerValue();
-        }
-
-        // Compute stereo using the block matching algorithm
-        cv::Mat disparity;
-        self->stereo(left, right, disparity, type);
-
-        // Wrap the returned disparity map
-        Local<Object> disparityWrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-        Matrix *disp = ObjectWrap::Unwrap<Matrix>(disparityWrap);
-        disp->mat = disparity;
-
-        NanReturnValue(disparityWrap);
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
+    // Optional 3rd arg, the disparty depth
+    int type = CV_16S;
+    if (args.Length() > 2) {
+      type = args[2]->IntegerValue();
     }
 
-};
+    // Compute stereo using the block matching algorithm
+    cv::Mat disparity;
+    self->stereo(left, right, disparity, type);
+
+    // Wrap the returned disparity map
+    Local < Object > disparityWrap =
+        NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+    Matrix *disp = ObjectWrap::Unwrap<Matrix>(disparityWrap);
+    disp->mat = disparity;
+
+    NanReturnValue(disparityWrap);
+
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
+}
 
 // Semi-Global Block matching
-
 v8::Persistent<FunctionTemplate> StereoSGBM::constructor;
 
-void
-StereoSGBM::Init(Handle<Object> target) {
-    NanScope();
+void StereoSGBM::Init(Handle<Object> target) {
+  NanScope();
 
-    Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(StereoSGBM::New);
-    NanAssignPersistent(constructor, ctor);
-    ctor->InstanceTemplate()->SetInternalFieldCount(1);
-    ctor->SetClassName(NanNew("StereoSGBM"));
+  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(StereoSGBM::New);
+  NanAssignPersistent(constructor, ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(NanNew("StereoSGBM"));
 
-    NODE_SET_PROTOTYPE_METHOD(ctor, "compute", Compute);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "compute", Compute);
 
-    target->Set(NanNew("StereoSGBM"), ctor->GetFunction());
+  target->Set(NanNew("StereoSGBM"), ctor->GetFunction());
 }
 
 NAN_METHOD(StereoSGBM::New) {
-    NanScope();
+  NanScope();
 
-    if (args.This()->InternalFieldCount() == 0)
-        NanThrowTypeError("Cannot instantiate without new");
+  if (args.This()->InternalFieldCount() == 0) {
+    NanThrowTypeError("Cannot instantiate without new");
+  }
 
-    StereoSGBM *stereo;
+  StereoSGBM *stereo;
 
-    if (args.Length() == 0)
-    {
-        stereo = new StereoSGBM();
+  if (args.Length() == 0) {
+    stereo = new StereoSGBM();
+  } else {
+    // If passing arguments, must pass the first 3 at least
+    if (args.Length() >= 3) {
+      switch (args.Length()) {
+        case 3:
+        stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(),
+            args[2]->IntegerValue());
+        break;
+        case 4:
+        stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(),
+            args[2]->IntegerValue(), args[3]->IntegerValue());
+        break;
+        case 5:
+        stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(),
+            args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue());
+        break;
+        case 6:
+        stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(),
+            args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(),
+            args[5]->IntegerValue());
+        break;
+        case 7:
+        stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(),
+            args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(),
+            args[5]->IntegerValue(), args[6]->IntegerValue());
+        break;
+        case 8:
+        stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(),
+            args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(),
+            args[5]->IntegerValue(), args[6]->IntegerValue(), args[7]->IntegerValue());
+        break;
+        case 9:
+        stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(),
+            args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(),
+            args[5]->IntegerValue(), args[6]->IntegerValue(), args[7]->IntegerValue(),
+            args[8]->IntegerValue());
+        break;
+        case 10:
+        stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(),
+            args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(),
+            args[5]->IntegerValue(), args[6]->IntegerValue(), args[7]->IntegerValue(),
+            args[8]->IntegerValue(), args[9]->IntegerValue());
+        break;
+        default:
+        stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(),
+            args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(),
+            args[5]->IntegerValue(), args[6]->IntegerValue(), args[7]->IntegerValue(),
+            args[8]->IntegerValue(), args[9]->IntegerValue(), args[10]->ToBoolean()->Value());
+        break;
+      }
+    } else {
+      NanThrowError("If overriding default settings, must pass minDisparity, numDisparities, and SADWindowSize");
+      NanReturnUndefined();
     }
-    else
-    {
-        // If passing arguments, must pass the first 3 at least
-        if (args.Length() >= 3)
-        {
-            switch (args.Length())
-            {
-                case 3:
-                    stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue());
-                    break;
+  }
 
-                case 4:
-                   stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue(), args[3]->IntegerValue());
-                   break;
-
-                case 5:
-                    stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue());
-                    break;
-
-                case 6:
-                    stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(), args[5]->IntegerValue());
-                    break;
-
-                case 7:
-                    stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(), args[5]->IntegerValue(), args[6]->IntegerValue());
-                    break;
-
-                case 8:
-                    stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(), args[5]->IntegerValue(), args[6]->IntegerValue(), args[7]->IntegerValue());
-                    break;
-
-                case 9:
-                    stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(), args[5]->IntegerValue(), args[6]->IntegerValue(), args[7]->IntegerValue(), args[8]->IntegerValue());
-                    break;
-
-                case 10:
-                    stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(), args[5]->IntegerValue(), args[6]->IntegerValue(), args[7]->IntegerValue(), args[8]->IntegerValue(), args[9]->IntegerValue());
-                    break;
-
-                default:
-                    stereo = new StereoSGBM(args[0]->IntegerValue(), args[1]->IntegerValue(), args[2]->IntegerValue(), args[3]->IntegerValue(), args[4]->IntegerValue(), args[5]->IntegerValue(), args[6]->IntegerValue(), args[7]->IntegerValue(), args[8]->IntegerValue(), args[9]->IntegerValue(), args[10]->ToBoolean()->Value());
-                    break;
-           }
-        }
-        else
-        {
-            NanThrowError("If overriding default settings, must pass minDisparity, numDisparities, and SADWindowSize");
-            NanReturnUndefined();
-        }
-    }
-
-    stereo->Wrap(args.Holder());
-    NanReturnValue(args.Holder());
+  stereo->Wrap(args.Holder());
+  NanReturnValue(args.Holder());
 }
 
-StereoSGBM::StereoSGBM()
-    : ObjectWrap(), stereo()
-{
+StereoSGBM::StereoSGBM() :
+    ObjectWrap(),
+    stereo() {
 
 }
 
-StereoSGBM::StereoSGBM(int minDisparity, int ndisparities, int SADWindowSize, int p1, int p2, int disp12MaxDiff, int preFilterCap, int uniquenessRatio, int speckleWindowSize, int speckleRange, bool fullDP)
-    : ObjectWrap(), stereo(minDisparity, ndisparities, SADWindowSize, p1, p2, disp12MaxDiff, preFilterCap, uniquenessRatio, speckleWindowSize, speckleRange, fullDP)
-{
-
+StereoSGBM::StereoSGBM(int minDisparity, int ndisparities, int SADWindowSize,
+    int p1, int p2, int disp12MaxDiff, int preFilterCap, int uniquenessRatio,
+    int speckleWindowSize, int speckleRange, bool fullDP) :
+    ObjectWrap(),
+    stereo(minDisparity, ndisparities, SADWindowSize, p1, p2, disp12MaxDiff,
+        preFilterCap, uniquenessRatio, speckleWindowSize, speckleRange, fullDP) {
 }
 
 // TODO make this async
-NAN_METHOD(StereoSGBM::Compute)
-{
-    SETUP_FUNCTION(StereoSGBM)
+NAN_METHOD(StereoSGBM::Compute) {
+  SETUP_FUNCTION(StereoSGBM)
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg 0, the 'left' image
-        Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-        cv::Mat left = m0->mat;
+    // Arg 0, the 'left' image
+    Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+    cv::Mat left = m0->mat;
 
-        // Arg 1, the 'right' image
-        Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
-        cv::Mat right = m1->mat;
+    // Arg 1, the 'right' image
+    Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
+    cv::Mat right = m1->mat;
 
-        // Compute stereo using the block matching algorithm
-        cv::Mat disparity;
-        self->stereo(left, right, disparity);
+    // Compute stereo using the block matching algorithm
+    cv::Mat disparity;
+    self->stereo(left, right, disparity);
 
-        // Wrap the returned disparity map
-        Local<Object> disparityWrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-        Matrix *disp = ObjectWrap::Unwrap<Matrix>(disparityWrap);
-        disp->mat = disparity;
+    // Wrap the returned disparity map
+    Local < Object > disparityWrap =
+        NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+    Matrix *disp = ObjectWrap::Unwrap<Matrix>(disparityWrap);
+    disp->mat = disparity;
 
-        NanReturnValue(disparityWrap);
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
-
-};
+    NanReturnValue(disparityWrap);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
+}
 
 // Graph cut
 
 v8::Persistent<FunctionTemplate> StereoGC::constructor;
 
-void
-StereoGC::Init(Handle<Object> target) {
-    NanScope();
+void StereoGC::Init(Handle<Object> target) {
+  NanScope();
 
-    Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(StereoGC::New);
-    NanAssignPersistent(constructor, ctor);
-    ctor->InstanceTemplate()->SetInternalFieldCount(1);
-    ctor->SetClassName(NanNew("StereoGC"));
+  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(StereoGC::New);
+  NanAssignPersistent(constructor, ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(NanNew("StereoGC"));
 
-    NODE_SET_PROTOTYPE_METHOD(ctor, "compute", Compute);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "compute", Compute);
 
-    target->Set(NanNew("StereoGC"), ctor->GetFunction());
+  target->Set(NanNew("StereoGC"), ctor->GetFunction());
 }
 
 NAN_METHOD(StereoGC::New) {
-    NanScope();
+  NanScope();
 
-    if (args.This()->InternalFieldCount() == 0)
-        NanThrowTypeError("Cannot instantiate without new");
+  if (args.This()->InternalFieldCount() == 0)
+  NanThrowTypeError("Cannot instantiate without new");
 
-    StereoGC *stereo;
+  StereoGC *stereo;
 
-    if (args.Length() == 0)
-    {
-        stereo = new StereoGC();
-    }
-    else if (args.Length() == 1)
-    {
-        stereo = new StereoGC(args[0]->IntegerValue()); // numberOfDisparities
-    }
-    else
-    {
-        stereo = new StereoGC(args[0]->IntegerValue(), args[1]->IntegerValue()); // max iterations
-    }
+  if (args.Length() == 0) {
+    stereo = new StereoGC();
+  } else if (args.Length() == 1) {
+    // numberOfDisparities
+    stereo = new StereoGC(args[0]->IntegerValue());
+  } else {
+    // max iterations
+    stereo = new StereoGC(args[0]->IntegerValue(), args[1]->IntegerValue());
+  }
 
-    stereo->Wrap(args.Holder());
-    NanReturnValue(args.Holder());
+  stereo->Wrap(args.Holder());
+  NanReturnValue(args.Holder());
 }
 
-StereoGC::StereoGC(int numberOfDisparities, int maxIters)
-: ObjectWrap()
-{
-    stereo = cvCreateStereoGCState(numberOfDisparities, maxIters);
+StereoGC::StereoGC(int numberOfDisparities, int maxIters) :
+    ObjectWrap() {
+  stereo = cvCreateStereoGCState(numberOfDisparities, maxIters);
 }
 
 // TODO make this async
-NAN_METHOD(StereoGC::Compute)
-{
-    SETUP_FUNCTION(StereoGC)
+NAN_METHOD(StereoGC::Compute) {
+  SETUP_FUNCTION(StereoGC)
 
-    try {
-        // Get the arguments
+  try {
+    // Get the arguments
 
-        // Arg 0, the 'left' image
-        Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
-        cv::Mat left = m0->mat;
+    // Arg 0, the 'left' image
+    Matrix* m0 = ObjectWrap::Unwrap<Matrix>(args[0]->ToObject());
+    cv::Mat left = m0->mat;
 
-        // Arg 1, the 'right' image
-        Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
-        cv::Mat right = m1->mat;
+    // Arg 1, the 'right' image
+    Matrix* m1 = ObjectWrap::Unwrap<Matrix>(args[1]->ToObject());
+    cv::Mat right = m1->mat;
 
-        // Compute stereo using the block matching algorithm
-        CvMat left_leg = left, right_leg = right;
-        CvMat *disp_left = cvCreateMat(left.rows, left.cols, CV_16S), *disp_right = cvCreateMat(right.rows, right.cols, CV_16S);
-        cvFindStereoCorrespondenceGC(&left_leg, &right_leg, disp_left, disp_right, self->stereo, 0);
+    // Compute stereo using the block matching algorithm
+    CvMat left_leg = left, right_leg = right;
+    CvMat *disp_left = cvCreateMat(left.rows, left.cols, CV_16S), *disp_right =
+        cvCreateMat(right.rows, right.cols, CV_16S);
+    cvFindStereoCorrespondenceGC(&left_leg, &right_leg, disp_left, disp_right,
+        self->stereo, 0);
 
-        cv::Mat disp16 = disp_left;
-        cv::Mat disparity(disp16.rows, disp16.cols, CV_8U);
-        disp16.convertTo(disparity, CV_8U, -16);
+    cv::Mat disp16 = disp_left;
+    cv::Mat disparity(disp16.rows, disp16.cols, CV_8U);
+    disp16.convertTo(disparity, CV_8U, -16);
 
-        // Wrap the returned disparity map
-        Local<Object> disparityWrap = NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-        Matrix *disp = ObjectWrap::Unwrap<Matrix>(disparityWrap);
-        disp->mat = disparity;
+    // Wrap the returned disparity map
+    Local < Object > disparityWrap =
+        NanNew(Matrix::constructor)->GetFunction()->NewInstance();
+    Matrix *disp = ObjectWrap::Unwrap<Matrix>(disparityWrap);
+    disp->mat = disparity;
 
-        NanReturnValue(disparityWrap);
-
-    } catch (cv::Exception &e) {
-        const char *err_msg = e.what();
-        NanThrowError(err_msg);
-        NanReturnUndefined();
-    }
-
-};
+    NanReturnValue(disparityWrap);
+  } catch (cv::Exception &e) {
+    const char *err_msg = e.what();
+    NanThrowError(err_msg);
+    NanReturnUndefined();
+  }
+}

--- a/src/Stereo.h
+++ b/src/Stereo.h
@@ -5,54 +5,49 @@
 
 class StereoBM: public node::ObjectWrap {
 public:
-    cv::StereoBM stereo;
+  cv::StereoBM stereo;
 
-    static Persistent<FunctionTemplate> constructor;
-    static void Init(Handle<Object> target);
-    static NAN_METHOD(New);
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(New);
 
-    StereoBM(int preset = cv::StereoBM::BASIC_PRESET, int ndisparities = 0, int SADWindowSize=21);
+  StereoBM(int preset = cv::StereoBM::BASIC_PRESET, int ndisparities = 0,
+      int SADWindowSize = 21);
 
-    JSFUNC(Compute);
+  JSFUNC(Compute)
+  ;
 };
 
 class StereoSGBM: public node::ObjectWrap {
 public:
-    cv::StereoSGBM stereo;
+  cv::StereoSGBM stereo;
 
-    static Persistent<FunctionTemplate> constructor;
-    static void Init(Handle<Object> target);
-    static NAN_METHOD(New);
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(New);
 
-    StereoSGBM();
-    StereoSGBM(int minDisparity,
-    int ndisparities,
-    int SADWindowSize,
-    int p1 = 0,
-    int p2 = 0,
-    int disp12MaxDiff = 0,
-    int preFilterCap = 0,
-    int uniquenessRatio = 0,
-    int speckleWindowSize = 0,
-    int speckleRange = 0,
-    bool fullDP = false);
+  StereoSGBM();
+  StereoSGBM(int minDisparity, int ndisparities, int SADWindowSize, int p1 = 0,
+      int p2 = 0, int disp12MaxDiff = 0, int preFilterCap = 0,
+      int uniquenessRatio = 0, int speckleWindowSize = 0, int speckleRange = 0,
+      bool fullDP = false);
 
-    JSFUNC(Compute);
+  JSFUNC(Compute);
 };
 
 struct CvStereoGCState;
 
 class StereoGC: public node::ObjectWrap {
 public:
-    CvStereoGCState *stereo;
+  CvStereoGCState *stereo;
 
-    static Persistent<FunctionTemplate> constructor;
-    static void Init(Handle<Object> target);
-    static NAN_METHOD(New);
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(New);
 
-    StereoGC(int numberOfDisparities = 16, int maxIterations = 2);
+  StereoGC(int numberOfDisparities = 16, int maxIterations = 2);
 
-    JSFUNC(Compute);
+  JSFUNC(Compute);
 };
 
 #endif

--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -5,155 +5,149 @@
 #include  <iostream>
 using namespace std;
 
-
 v8::Persistent<FunctionTemplate> VideoCaptureWrap::constructor;
 
 struct videocapture_baton {
 
-	Persistent<Function> cb;
-	VideoCaptureWrap *vc;
-	Matrix *im;
+  Persistent<Function> cb;
+  VideoCaptureWrap *vc;
+  Matrix *im;
 
-	uv_work_t request;
+  uv_work_t request;
 };
 
-
-void
-VideoCaptureWrap::Init(Handle<Object> target) {
+void VideoCaptureWrap::Init(Handle<Object> target) {
   NanScope();
 
-	//Class
+  //Class
   Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(VideoCaptureWrap::New);
   NanAssignPersistent(constructor, ctor);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
   ctor->SetClassName(NanNew("VideoCapture"));
-  
-  // Prototype
-	//Local<ObjectTemplate> proto = constructor->PrototypeTemplate();
 
-	NODE_SET_PROTOTYPE_METHOD(ctor, "read", Read);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "setWidth", SetWidth);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "setHeight", SetHeight);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "setPosition", SetPosition);
+  // Prototype
+  //Local<ObjectTemplate> proto = constructor->PrototypeTemplate();
+
+  NODE_SET_PROTOTYPE_METHOD(ctor, "read", Read);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "setWidth", SetWidth);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "setHeight", SetHeight);
+  NODE_SET_PROTOTYPE_METHOD(ctor, "setPosition", SetPosition);
   NODE_SET_PROTOTYPE_METHOD(ctor, "close", Close);
   NODE_SET_PROTOTYPE_METHOD(ctor, "ReadSync", ReadSync);
   NODE_SET_PROTOTYPE_METHOD(ctor, "grab", Grab);
   NODE_SET_PROTOTYPE_METHOD(ctor, "retrieve", Retrieve);
 
-	target->Set(NanNew("VideoCapture"), ctor->GetFunction());
-};    
+  target->Set(NanNew("VideoCapture"), ctor->GetFunction());
+}
 
 NAN_METHOD(VideoCaptureWrap::New) {
-	NanScope();
+  NanScope();
 
   if (args.This()->InternalFieldCount() == 0)
-		return NanThrowTypeError("Cannot Instantiate without new");
+  return NanThrowTypeError("Cannot Instantiate without new");
 
-	VideoCaptureWrap *v;
+  VideoCaptureWrap *v;
 
-	if (args[0]->IsNumber()){
-		v = new VideoCaptureWrap(args[0]->NumberValue());
-	} else {
+  if (args[0]->IsNumber()) {
+    v = new VideoCaptureWrap(args[0]->NumberValue());
+  } else {
     //TODO - assumes that we have string, verify
     v = new VideoCaptureWrap(std::string(*NanAsciiString(args[0]->ToString())));
   }
 
+  v->Wrap(args.This());
 
-	v->Wrap(args.This());
-
-	NanReturnValue(args.This());
+  NanReturnValue(args.This());
 }
 
-VideoCaptureWrap::VideoCaptureWrap(int device){
-
-	NanScope();
-	cap.open(device);
-
-	if(!cap.isOpened()){
-    NanThrowError("Camera could not be opened");
-	}
-}
-
-VideoCaptureWrap::VideoCaptureWrap(const std::string& filename){
+VideoCaptureWrap::VideoCaptureWrap(int device) {
   NanScope();
-	cap.open(filename);
+  cap.open(device);
+
+  if(!cap.isOpened()) {
+    NanThrowError("Camera could not be opened");
+  }
+}
+
+VideoCaptureWrap::VideoCaptureWrap(const std::string& filename) {
+  NanScope();
+  cap.open(filename);
   // TODO! At the moment this only takes a full path - do relative too.
-	if(!cap.isOpened()){
+  if(!cap.isOpened()) {
     NanThrowError("Video file could not be opened (opencv reqs. non relative paths)");
-	}
-
+  }
 }
 
-NAN_METHOD(VideoCaptureWrap::SetWidth){
+NAN_METHOD(VideoCaptureWrap::SetWidth) {
+  NanScope();
+  VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
 
-	NanScope();
-	VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
+  if(args.Length() != 1)
+  NanReturnUndefined();
 
-	if(args.Length() != 1)
-		NanReturnUndefined();
-	
-	int w = args[0]->IntegerValue();
+  int w = args[0]->IntegerValue();
 
-	if(v->cap.isOpened())
-		v->cap.set(CV_CAP_PROP_FRAME_WIDTH, w);
+  if(v->cap.isOpened())
+  v->cap.set(CV_CAP_PROP_FRAME_WIDTH, w);
 
-	NanReturnUndefined();
+  NanReturnUndefined();
 }
 
-NAN_METHOD(VideoCaptureWrap::SetHeight){
+NAN_METHOD(VideoCaptureWrap::SetHeight) {
+  NanScope();
+  VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
 
-	NanScope();
-	VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
+  if(args.Length() != 1)
+  NanReturnUndefined();
 
-	if(args.Length() != 1)
-		NanReturnUndefined();
-	
-	int h = args[0]->IntegerValue();
+  int h = args[0]->IntegerValue();
 
-	v->cap.set(CV_CAP_PROP_FRAME_HEIGHT, h);
+  v->cap.set(CV_CAP_PROP_FRAME_HEIGHT, h);
 
-	NanReturnUndefined();
+  NanReturnUndefined();
 }
 
-NAN_METHOD(VideoCaptureWrap::SetPosition){
+NAN_METHOD(VideoCaptureWrap::SetPosition) {
+  NanScope();
+  VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
 
-	NanScope();
-	VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
+  if(args.Length() != 1)
+  NanReturnUndefined();
 
-	if(args.Length() != 1)
-		NanReturnUndefined();
-	
-	int pos = args[0]->IntegerValue();
+  int pos = args[0]->IntegerValue();
 
-	v->cap.set(CV_CAP_PROP_POS_FRAMES, pos);
+  v->cap.set(CV_CAP_PROP_POS_FRAMES, pos);
 
-	NanReturnUndefined();
+  NanReturnUndefined();
 }
 
-NAN_METHOD(VideoCaptureWrap::Close){
+NAN_METHOD(VideoCaptureWrap::Close) {
+  NanScope();
+  VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
 
-	NanScope();
-	VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
+  v->cap.release();
 
-	v->cap.release();
-
-	NanReturnUndefined();
+  NanReturnUndefined();
 }
 
-
-class AsyncVCWorker : public NanAsyncWorker {
- public:
+class AsyncVCWorker: public NanAsyncWorker {
+public:
   AsyncVCWorker(NanCallback *callback, VideoCaptureWrap* vc,
-                bool retrieve = false, int channel = 0)
-    : NanAsyncWorker(callback), vc(vc),
-      retrieve(retrieve), channel(channel) {}
-  ~AsyncVCWorker() {}
+  bool retrieve = false, int channel = 0) :
+      NanAsyncWorker(callback),
+      vc(vc),
+      retrieve(retrieve),
+      channel(channel) {
+  }
+
+  ~AsyncVCWorker() {
+  }
 
   // Executed inside the worker-thread.
   // It is not safe to access V8, or V8 data structures
   // here, so everything we need for input and output
   // should go on `this`.
-  void Execute () {
+  void Execute() {
     if (retrieve) {
       if (!this->vc->cap.retrieve(mat, channel)) {
         SetErrorMessage("retrieve failed");
@@ -166,18 +160,18 @@ class AsyncVCWorker : public NanAsyncWorker {
   // Executed when the async work is complete
   // this function will be run inside the main event loop
   // so it is safe to use V8 again
-  void HandleOKCallback () {
+  void HandleOKCallback() {
     NanScope();
-    
+
     Local<Object> im_to_return= NanNew(Matrix::constructor)->GetFunction()->NewInstance();
-	  Matrix *img = ObjectWrap::Unwrap<Matrix>(im_to_return);
-	  img->mat = mat;
+    Matrix *img = ObjectWrap::Unwrap<Matrix>(im_to_return);
+    img->mat = mat;
 
     Local<Value> argv[] = {
-        NanNull()
+      NanNull()
       , im_to_return
     };
-    
+
     TryCatch try_catch;
     callback->Call(2, argv);
     if (try_catch.HasCaught()) {
@@ -185,61 +179,58 @@ class AsyncVCWorker : public NanAsyncWorker {
     }
   }
 
- private:
+private:
   VideoCaptureWrap *vc;
   cv::Mat mat;
   bool retrieve;
   int channel;
 };
 
-
-
 NAN_METHOD(VideoCaptureWrap::Read) {
+  NanScope();
+  VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
 
-	NanScope();
-	VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
-
-	REQ_FUN_ARG(0, cb);
+  REQ_FUN_ARG(0, cb);
 
   NanCallback *callback = new NanCallback(cb.As<Function>());
   NanAsyncQueueWorker(new AsyncVCWorker(callback, v));
-	
-	NanReturnUndefined();
+
+  NanReturnUndefined();
 }
 
-
 NAN_METHOD(VideoCaptureWrap::ReadSync) {
-
-	NanScope();
-	VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
+  NanScope();
+  VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
 
   Local<Object> im_to_return= NanNew(Matrix::constructor)->GetFunction()->NewInstance();
   Matrix *img = ObjectWrap::Unwrap<Matrix>(im_to_return);
 
   v->cap.read(img->mat);
 
-	NanReturnValue(im_to_return);
+  NanReturnValue(im_to_return);
 }
 
+class AsyncGrabWorker: public NanAsyncWorker {
+public:
+  AsyncGrabWorker(NanCallback *callback, VideoCaptureWrap* vc) :
+      NanAsyncWorker(callback),
+      vc(vc) {
+  }
 
-class AsyncGrabWorker : public NanAsyncWorker {
- public:
-  AsyncGrabWorker(NanCallback *callback, VideoCaptureWrap* vc)
-    : NanAsyncWorker(callback), vc(vc) {}
-  ~AsyncGrabWorker() {}
+  ~AsyncGrabWorker() {
+  }
 
-  void Execute () {
+  void Execute() {
     if (!this->vc->cap.grab()) {
       SetErrorMessage("grab failed");
     }
   }
 
- private:
+private:
   VideoCaptureWrap *vc;
 };
 
 NAN_METHOD(VideoCaptureWrap::Grab) {
-
   NanScope();
   VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
 
@@ -252,7 +243,6 @@ NAN_METHOD(VideoCaptureWrap::Grab) {
 }
 
 NAN_METHOD(VideoCaptureWrap::Retrieve) {
-
   NanScope();
   VideoCaptureWrap *v = ObjectWrap::Unwrap<VideoCaptureWrap>(args.This());
 
@@ -265,4 +255,3 @@ NAN_METHOD(VideoCaptureWrap::Retrieve) {
 
   NanReturnUndefined();
 }
-

--- a/src/VideoCaptureWrap.h
+++ b/src/VideoCaptureWrap.h
@@ -1,32 +1,32 @@
 #include "OpenCV.h"
 
 class VideoCaptureWrap: public node::ObjectWrap {
-  public:
-      cv::VideoCapture cap;
+public:
+  cv::VideoCapture cap;
 
-      static Persistent<FunctionTemplate> constructor;
-      static void Init(Handle<Object> target);
-      static NAN_METHOD(New);
-      
-      VideoCaptureWrap(const std::string& filename);
-      VideoCaptureWrap(int device); 
+  static Persistent<FunctionTemplate> constructor;
+  static void Init(Handle<Object> target);
+  static NAN_METHOD(New);
 
-      static NAN_METHOD(Read);
-      static NAN_METHOD(ReadSync);
+  VideoCaptureWrap(const std::string& filename);
+  VideoCaptureWrap(int device);
 
-      static NAN_METHOD(Grab);
-      static NAN_METHOD(Retrieve);
+  static NAN_METHOD(Read);
+  static NAN_METHOD(ReadSync);
 
-      //(Optional) For setting width and height of the input video stream 
-      static NAN_METHOD(SetWidth);
-      static NAN_METHOD(SetHeight);
-      
-      // to set frame position
-      static NAN_METHOD(SetPosition);
+  static NAN_METHOD(Grab);
+  static NAN_METHOD(Retrieve);
 
-      static NAN_METHOD(GetFrameAt);
+  // (Optional) For setting width and height of the input video stream
+  static NAN_METHOD(SetWidth);
+  static NAN_METHOD(SetHeight);
 
-      //close the stream
-      static NAN_METHOD(Close);
+  // to set frame position
+  static NAN_METHOD(SetPosition);
+
+  static NAN_METHOD(GetFrameAt);
+
+  //close the stream
+  static NAN_METHOD(Close);
 };
 

--- a/src/init.cc
+++ b/src/init.cc
@@ -15,31 +15,29 @@
 #include "Stereo.h"
 #include "BackgroundSubtractor.h"
 
-extern "C" void
-init(Handle<Object> target) {
-    NanScope();
-    OpenCV::Init(target);
+extern "C" void init(Handle<Object> target) {
+  NanScope();
+  OpenCV::Init(target);
 
-    Point::Init(target);
-    Matrix::Init(target);
-    CascadeClassifierWrap::Init(target);
-    VideoCaptureWrap::Init(target);
-    Contour::Init(target);
-    TrackedObject::Init(target);
-    NamedWindow::Init(target);
-    Constants::Init(target);
-    Calib3D::Init(target);
-    ImgProc::Init(target);
-    StereoBM::Init(target);
-    StereoSGBM::Init(target);
-    StereoGC::Init(target);
+  Point::Init(target);
+  Matrix::Init(target);
+  CascadeClassifierWrap::Init(target);
+  VideoCaptureWrap::Init(target);
+  Contour::Init(target);
+  TrackedObject::Init(target);
+  NamedWindow::Init(target);
+  Constants::Init(target);
+  Calib3D::Init(target);
+  ImgProc::Init(target);
+  StereoBM::Init(target);
+  StereoSGBM::Init(target);
+  StereoGC::Init(target);
 
-   #if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4
-      BackgroundSubtractorWrap::Init(target);
-      Features::Init(target);
-      FaceRecognizerWrap::Init(target);
-   #endif
-
+#if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4
+  BackgroundSubtractorWrap::Init(target);
+  Features::Init(target);
+  FaceRecognizerWrap::Init(target);
+#endif
 };
 
 NODE_MODULE(opencv, init)


### PR DESCRIPTION
@peterbraden ?

Main things I fixed are
- 2 space indentation
- remove tabs
- 4 space indentation for line breaks
- Add curlies around single statement if/else

Add eclipse code style formatting files for both native and JS code. Will push a separate change for JS formatting as this was getting pretty big. 