### PR TITLE
Fixed bug with compile in Visual Studio.

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -1656,8 +1656,8 @@ NAN_METHOD(Matrix::Threshold) {
         "Use \"Binary\" (default), \"Binary Inverted\", "
         "\"Threshold Truncated\", \"Threshold to Zero\" "
         "or \"Threshold to Zero Inverted\"";
-	  char *errorMessage;
-	  errorMessage = new char[strlen(typeString) + strlen(text) + 2];
+      char *errorMessage;
+      errorMessage = new char[strlen(typeString) + strlen(text) + 2];
       strcpy(errorMessage, "\"");
       strcat(errorMessage, typeString);
       strcat(errorMessage, text);
@@ -1680,8 +1680,8 @@ NAN_METHOD(Matrix::Threshold) {
       char *algo = *algorithm;
       char text[] = "\" is no supported threshold algorithm. "
         "Use \"Simple\" (default) or \"Otsu\".";
-	  char *errorMessage;
-	  errorMessage = new char[strlen(algo) + strlen(text) + 2];
+      char *errorMessage;
+      errorMessage = new char[strlen(algo) + strlen(text) + 2];
       strcpy(errorMessage, "\"");
       strcat(errorMessage, algo);
       strcat(errorMessage, text);

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -1656,7 +1656,8 @@ NAN_METHOD(Matrix::Threshold) {
         "Use \"Binary\" (default), \"Binary Inverted\", "
         "\"Threshold Truncated\", \"Threshold to Zero\" "
         "or \"Threshold to Zero Inverted\"";
-      char errorMessage[strlen(typeString) + strlen(text) + 2];
+	  char *errorMessage;
+	  errorMessage = new char[strlen(typeString) + strlen(text) + 2];
       strcpy(errorMessage, "\"");
       strcat(errorMessage, typeString);
       strcat(errorMessage, text);
@@ -1679,7 +1680,8 @@ NAN_METHOD(Matrix::Threshold) {
       char *algo = *algorithm;
       char text[] = "\" is no supported threshold algorithm. "
         "Use \"Simple\" (default) or \"Otsu\".";
-      char errorMessage[strlen(algo) + strlen(text) + 2];
+	  char *errorMessage;
+	  errorMessage = new char[strlen(algo) + strlen(text) + 2];
       strcpy(errorMessage, "\"");
       strcat(errorMessage, algo);
       strcat(errorMessage, text);


### PR DESCRIPTION
Replaced _errorMessage_ to dynamically array, because Visual Studio require that the size was constant:
`Error: expression must have a constant value`.