### PR TITLE
Add support for GetRotationMatrix2D and WarpAffine

### DIFF
--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -51,6 +51,8 @@ public:
 
   JSFUNC(Resize)
   JSFUNC(Rotate)
+  JSFUNC(GetRotationMatrix2D)
+  JSFUNC(WarpAffine)
   JSFUNC(PyrDown)
   JSFUNC(PyrUp)
 


### PR DESCRIPTION
@peterbraden ?

Requesting to add these functions for greater flexibility then is currently provided by the rotate function. I initially updated the rotate function to pass additional arguments but that seemed inappropriate for a rotate function. 