### PR TITLE
Make GetRotationMatrix2D static

### DIFF
--- a/test/unit.js
+++ b/test/unit.js
@@ -112,6 +112,10 @@ test('Matrix functions', function(assert) {
   assert.equal(matNew.height(), 1);
   assert.equal(matNew.width(), 5625);
 
+  // GetRotationMatrix2D
+  mat = cv.Matrix.getRotationMatrix2D(0, 0, 90, 1.0);
+  assert.deepEqual(mat.size(), [2,3], 'GetRotationMatrix2D');
+
   assert.end();
 })
 


### PR DESCRIPTION
This avoids unnecessarily creating a matrix only to get replaced by the new matrix returned by GetRotationMatrix2D function. Also added a test for this function.

@peterbraden ?