### PR TITLE
Fix contours example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ functions for accessing, computing with, and altering the contours contained in 
 See [relevant source code](src/Contours.cc) and [examples](examples/)
 
 ```javascript
-var contours = im.findContours;
+var contours = im.findContours();
 
 // Count of contours in the Contours object
 contours.size();


### PR DESCRIPTION
`#findContours` needs to be called, not just referenced.