### PR TITLE
Simplify building on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,18 @@ cool, I'd love to hear about it!
 You'll need OpenCV 2.3.1 or newer installed before installing node-opencv.
 
 ## Specific for Windows
-1. Download and install opencv (Be sure to use a 2.4 version) @
+1. Download and install OpenCV (Be sure to use a 2.4 version) @
 http://opencv.org/downloads.html
 For these instructions we will assume OpenCV is put at C:\OpenCV, but you can
 adjust accordingly.
 
-2. Add the following to your PATH variable
-    C:\OpenCV\build\x64\vc12\bin;
-   The "x64" needs to match the version of NodeJS you are using.
+2. If you haven't already, create a system variable called OPENCV_DIR and set it
+   to C:\OpenCV\build\x64\vc12
 
-   Also set OPENCV_DIR to C:\OpenCV\build
+   Make sure the "x64" part matches the version of NodeJS you are using.
+
+   Also add the following to your system PATH
+        ;%OPENCV_DIR%\bin
 
 3. Install Visual Studio 2013. Make sure to get the C++ components.
    You can use a different edition, just make sure OpenCV supports it, and you

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-opencv 
+# node-opencv
 
 [![Build Status](https://secure.travis-ci.org/peterbraden/node-opencv.png)](http://travis-ci.org/peterbraden/node-opencv)
 
@@ -16,41 +16,25 @@ cool, I'd love to hear about it!
 You'll need OpenCV 2.3.1 or newer installed before installing node-opencv.
 
 ## Specific for Windows
-1. Download Install opencv @ - (I used version 2.4.4)
+1. Download and install opencv (Be sure to use a 2.4 version) @
 http://opencv.org/downloads.html
-Put it in c:\opencv
+For these instructions we will assume OpenCV is put at C:\OpenCV, but you can
+adjust accordingly.
 
-2. Install python version 2.7 @
-http://www.python.org/download/releases/2.7/
-put it in c:\python27
+2. Add the following to your PATH variable
+    C:\OpenCV\build\x64\vc12\bin;
+   The "x64" needs to match the version of NodeJS you are using.
 
-3. install pkg-config by downloading the all in one bundle @ - (I used Gtk+ 3.6.4)
-http://www.gtk.org/download/win64.php
-put it in c:\pkg-config
+   Also set OPENCV_DIR to C:\OpenCV\build
 
-4. Add the following to your path variables
-C:\pkg-config\bin;C:\OpenCV\build\x64\vc11\bin;
+3. Install Visual Studio 2013. Make sure to get the C++ components.
+   You can use a different edition, just make sure OpenCV supports it, and you
+   set the "vcxx" part of the variables above to match.
 
-5. Install visual-studio in 4 steps
-
-  - install Visual C++ 2010 Express
-  
-  - install Windows SDK for windows 7 and .net framework 4
-  
-  - install Visual Studio 2010 Service Pack 1
-  
-  - install Visual C++ 2010 Service Pack 1 Compiler
-
-
-6. Download npeterbraden/node-opencv fork
+4. Download peterbraden/node-opencv fork
 git clone https://github.com/peterbraden/node-opencv
 
-7. edit file src/Matrix.cpp
-put "inline double round( double d ) { return floor( d + 0.5);}" below "cv::Rect* setRect(Local<Object> objRect, cv::Rect &result);"
-
-8. run npm install
-
-Then:
+5. run npm install
 
 ```bash
 $ npm install opencv
@@ -175,8 +159,8 @@ im.line([x1,y1], [x2, y2])
 
 #### Object Detection
 
-There is a shortcut method for 
-[Viola-Jones Haar Cascade](http://www.cognotics.com/opencv/servo_2007_series/part_2/sidebar.html) object 
+There is a shortcut method for
+[Viola-Jones Haar Cascade](http://www.cognotics.com/opencv/servo_2007_series/part_2/sidebar.html) object
 detection. This can be used for face detection etc.
 
 ```javascript
@@ -239,4 +223,3 @@ contours.convexHull(index, clockwise);
 ## MIT License
 The library is distributed under the MIT License - if for some reason that
 doesn't work for you please get in touch.
-

--- a/binding.gyp
+++ b/binding.gyp
@@ -24,12 +24,12 @@
       ],
 
       "libraries": [
-        "<!@(pkg-config --libs opencv)"
+        "<!@(node utils/find-opencv.js --libs)"
       ],
       # For windows
 
       "include_dirs": [
-        "<!@(pkg-config --cflags opencv)",
+        "<!@(node utils/find-opencv.js --cflags)",
         "<!(node -e \"require('nan')\")"
       ],
 
@@ -45,8 +45,10 @@
         }],
         [ "OS==\"win\"", {
             "cflags": [
-              "<!@(pkg-config --cflags \"opencv >= 2.4.9\" )",
               "-Wall"
+            ],
+            "defines": [
+                "WIN"
             ],
             "msvs_settings": {
               "VCCLCompilerTool": {

--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -1,6 +1,16 @@
 #ifndef __NODE_OPENCV_H__
 #define __NODE_OPENCV_H__
 
+#ifdef WIN
+    /*
+        This is needed on Windows for Visual Studio to not throw an error in the
+        build/include/opencv2/flann/any.h file in OpenCV.
+    */
+    namespace std{ typedef type_info type_info; }
+#endif
+
+
+
 #include <v8.h>
 #include <node.h>
 #include <node_object_wrap.h>

--- a/utils/find-opencv.js
+++ b/utils/find-opencv.js
@@ -1,0 +1,115 @@
+var exec = require("child_process").exec;
+var fs = require("fs");
+var flag = process.argv[2];
+
+function main(){
+
+    //Try using pkg-config, but if it fails and it is on Windows, try the fallback
+    exec("pkg-config opencv " + flag, function(error, stdout, stderr){
+        if(error){
+            if(process.platform === "win32"){
+                fallback();
+            }
+        }
+        else{
+            console.log(stdout);
+        }
+    });
+}
+
+//======================Windows Specific=======================================
+
+function fallback(){
+    exec("echo %OPENCV_DIR%", function(error, stdout, stderr){
+        stdout = cleanupEchoOutput(stdout);
+        if(error){
+            console.log("ERROR: There was an error reading OPENCV_DIR");
+        }
+        else if(stdout === "%OPENCV_DIR%") {
+            console.log("ERROR: OPENCV_DIR doesn't seem to be defined");
+        }
+        else {
+            getVisualStudioVersion(function(version){
+                getProcessArch(function(bits){
+                    printPaths(stdout, version, bits);
+                });
+            });
+        }
+    });
+}
+
+function printPaths(opencvPath, version, bits){
+    if(flag === "--cflags") {
+        console.log("\"" + opencvPath + "include\"");
+        console.log("\"" + opencvPath + "include\\opencv\"");
+    }
+    else if(flag === "--libs") {
+        var libPath = opencvPath + bits + "\\vc" + version + "\\lib\\";
+
+        fs.readdir(libPath, function(err, files){
+            if(err){
+                console.log("ERROR: couldn't read the lib directory");
+                console.log(err);
+            }
+
+            var libs = "";
+            for(var i = 0; i < files.length; i++){
+                if(getExtension(files[i]) === "lib"){
+                    libs = libs + " \"" + libPath + files[i] + "\" \r\n ";
+                }
+            }
+            console.log(libs);
+        });
+    }
+    else {
+        console.log("Error: unknown argument '" + flag + "'");
+    }
+}
+
+//This gets the architecture of the NodeJS that is running this script,
+//either x86 or x64
+function getProcessArch(cb){
+    exec("echo %PROCESSOR_ARCHITECTURE%", function(error, stdout, stderr) {
+        if(!error) {
+            var arch = cleanupEchoOutput(stdout);
+            if(arch === "AMD64"){
+                cb("x64");
+            }
+            else if(arch === "x86"){
+                cb("x86");
+            }
+            else {
+                console.log("ERROR: Unrecognized architecture");
+            }
+        }
+        else {
+            console.log("ERROR: There was an error getting the architecture");
+        }
+    });
+}
+
+function getVisualStudioVersion(cb, version){
+    if(typeof(version) === "undefined") version = 11;
+    exec("reg query HKEY_CLASSES_ROOT\\VisualStudio.DTE." + version + ".0",
+        function(error, stdout, stderr){
+            if(!error){
+                cb(version);
+            }
+            else if(version < 13) {
+                //Try the next version
+                getVisualStudioVersion(cb, version + 1);
+            }
+            else {
+                console.log("ERROR: Can't find Visual Studio");
+            }
+        });
+}
+
+function cleanupEchoOutput(s){
+    return s.slice(0, s.length - 2);
+}
+
+function getExtension(s){
+    return s.substr(s.lastIndexOf(".") + 1);
+}
+main();

--- a/utils/find-opencv.js
+++ b/utils/find-opencv.js
@@ -3,12 +3,14 @@ var fs = require("fs");
 var flag = process.argv[2];
 
 function main(){
-
     //Try using pkg-config, but if it fails and it is on Windows, try the fallback
     exec("pkg-config opencv " + flag, function(error, stdout, stderr){
         if(error){
             if(process.platform === "win32"){
                 fallback();
+            }
+            else{
+                throw new Error("ERROR: pkg-config couldn't find OpenCV");
             }
         }
         else{
@@ -23,33 +25,28 @@ function fallback(){
     exec("echo %OPENCV_DIR%", function(error, stdout, stderr){
         stdout = cleanupEchoOutput(stdout);
         if(error){
-            console.log("ERROR: There was an error reading OPENCV_DIR");
+            throw new Error("ERROR: There was an error reading OPENCV_DIR");
         }
         else if(stdout === "%OPENCV_DIR%") {
-            console.log("ERROR: OPENCV_DIR doesn't seem to be defined");
+            throw new Error("ERROR: OPENCV_DIR doesn't seem to be defined");
         }
         else {
-            getVisualStudioVersion(function(version){
-                getProcessArch(function(bits){
-                    printPaths(stdout, version, bits);
-                });
-            });
+            printPaths(stdout);
         }
     });
 }
 
-function printPaths(opencvPath, version, bits){
+function printPaths(opencvPath){
     if(flag === "--cflags") {
-        console.log("\"" + opencvPath + "include\"");
-        console.log("\"" + opencvPath + "include\\opencv\"");
+        console.log("\"" + opencvPath + "\\..\\..\\include\"");
+        console.log("\"" + opencvPath + "\\..\\..\\include\\opencv\"");
     }
     else if(flag === "--libs") {
-        var libPath = opencvPath + bits + "\\vc" + version + "\\lib\\";
+        var libPath = opencvPath + "\\lib\\";
 
         fs.readdir(libPath, function(err, files){
             if(err){
-                console.log("ERROR: couldn't read the lib directory");
-                console.log(err);
+                throw new Error("ERROR: couldn't read the lib directory " + err);
             }
 
             var libs = "";
@@ -62,47 +59,8 @@ function printPaths(opencvPath, version, bits){
         });
     }
     else {
-        console.log("Error: unknown argument '" + flag + "'");
+        throw new Error("Error: unknown argument '" + flag + "'");
     }
-}
-
-//This gets the architecture of the NodeJS that is running this script,
-//either x86 or x64
-function getProcessArch(cb){
-    exec("echo %PROCESSOR_ARCHITECTURE%", function(error, stdout, stderr) {
-        if(!error) {
-            var arch = cleanupEchoOutput(stdout);
-            if(arch === "AMD64"){
-                cb("x64");
-            }
-            else if(arch === "x86"){
-                cb("x86");
-            }
-            else {
-                console.log("ERROR: Unrecognized architecture");
-            }
-        }
-        else {
-            console.log("ERROR: There was an error getting the architecture");
-        }
-    });
-}
-
-function getVisualStudioVersion(cb, version){
-    if(typeof(version) === "undefined") version = 11;
-    exec("reg query HKEY_CLASSES_ROOT\\VisualStudio.DTE." + version + ".0",
-        function(error, stdout, stderr){
-            if(!error){
-                cb(version);
-            }
-            else if(version < 13) {
-                //Try the next version
-                getVisualStudioVersion(cb, version + 1);
-            }
-            else {
-                console.log("ERROR: Can't find Visual Studio");
-            }
-        });
 }
 
 function cleanupEchoOutput(s){


### PR DESCRIPTION
I created a quick NodeJS script to simplify the build process on Windows. 

Changes:
- Removed the need for pkg-config on Windows (it is still tried first for those who have it set up)
- Updated the README so the instructions are accurate
- I removed the instructions to modify the Matrix.cc file. It seems to compile fine without modifying it and causes a compilation error if I do. Maybe just my machine?
- Added a WIN define, that is used to stop a Visual Studio compile error. This should close #341. This seems to describe the error: http://stackoverflow.com/questions/1687860/why-is-type-info-declared-outside-namespace-std
- Removed the OpenCV version check for Windows.

Thanks for taking a look!
