### PR TITLE
Added getFrameCount method to VideoCapture

### DIFF
--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -33,7 +33,7 @@ void VideoCaptureWrap::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "setHeight", SetHeight);
   Nan::SetPrototypeMethod(ctor, "setPosition", SetPosition);
   Nan::SetPrototypeMethod(ctor, "getFrameAt", GetFrameAt);
-  Nan::SetPrototypeMethod(ctor, "nFrames", NumFrames);
+  Nan::SetPrototypeMethod(ctor, "getFrameCount", GetFrameCount);
   Nan::SetPrototypeMethod(ctor, "close", Close);
   Nan::SetPrototypeMethod(ctor, "ReadSync", ReadSync);
   Nan::SetPrototypeMethod(ctor, "grab", Grab);
@@ -95,7 +95,7 @@ NAN_METHOD(VideoCaptureWrap::SetWidth) {
   return;
 }
 
-NAN_METHOD(VideoCaptureWrap::NumFrames) {
+NAN_METHOD(VideoCaptureWrap::GetFrameCount) {
   Nan::HandleScope scope;
   VideoCaptureWrap *v = Nan::ObjectWrap::Unwrap<VideoCaptureWrap>(info.This());
 

--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -33,6 +33,7 @@ void VideoCaptureWrap::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "setHeight", SetHeight);
   Nan::SetPrototypeMethod(ctor, "setPosition", SetPosition);
   Nan::SetPrototypeMethod(ctor, "getFrameAt", GetFrameAt);
+  Nan::SetPrototypeMethod(ctor, "nFrames", NumFrames);
   Nan::SetPrototypeMethod(ctor, "close", Close);
   Nan::SetPrototypeMethod(ctor, "ReadSync", ReadSync);
   Nan::SetPrototypeMethod(ctor, "grab", Grab);
@@ -92,6 +93,15 @@ NAN_METHOD(VideoCaptureWrap::SetWidth) {
   v->cap.set(CV_CAP_PROP_FRAME_WIDTH, w);
 
   return;
+}
+
+NAN_METHOD(VideoCaptureWrap::NumFrames) {
+  Nan::HandleScope scope;
+  VideoCaptureWrap *v = Nan::ObjectWrap::Unwrap<VideoCaptureWrap>(info.This());
+
+  int cnt = int(v->cap.get(CV_CAP_PROP_FRAME_COUNT));
+
+  info.GetReturnValue().Set(Nan::New<Number>(cnt));
 }
 
 NAN_METHOD(VideoCaptureWrap::SetHeight) {

--- a/src/VideoCaptureWrap.h
+++ b/src/VideoCaptureWrap.h
@@ -23,7 +23,7 @@ public:
 
   // to set frame position
   static NAN_METHOD(SetPosition);
-  static NAN_METHOD(NumFrames);
+  static NAN_METHOD(GetFrameCount);
 
   static NAN_METHOD(GetFrameAt);
 

--- a/src/VideoCaptureWrap.h
+++ b/src/VideoCaptureWrap.h
@@ -23,6 +23,7 @@ public:
 
   // to set frame position
   static NAN_METHOD(SetPosition);
+  static NAN_METHOD(NumFrames);
 
   static NAN_METHOD(GetFrameAt);
 


### PR DESCRIPTION
When working with the video it is very important to know its size. This simple pull request add this functionality.