### PR TITLE
Base OpenCV 3 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ cool, I'd love to hear about it!
 
 ## Install
 
-You'll need OpenCV 2.3.1 or newer installed before installing node-opencv.
+You'll need OpenCV 2.3.1 or newer installed before installing node-opencv.  Note
+that OpenCV 3.x is not yet fully supported.
 
 ## Specific for Windows
 1. Download and install OpenCV (Be sure to use a 2.4 version) @

--- a/binding.gyp
+++ b/binding.gyp
@@ -39,7 +39,7 @@
       "conditions": [
         [ "OS==\"linux\" or OS==\"freebsd\" or OS==\"openbsd\" or OS==\"solaris\" or OS==\"aix\"", {
             "cflags": [
-              "<!@(pkg-config --cflags \"opencv >= 2.3.1\" )",
+              "<!@(node utils/find-opencv.js --cflags)",
               "-Wall"
             ]
         }],
@@ -64,7 +64,7 @@
               "-mmacosx-version-min=10.7",
             "-std=c++11",
             "-stdlib=libc++",
-            "<!@(pkg-config --cflags opencv)"
+            "<!@(node utils/find-opencv.js --cflags)",
               ],
             "GCC_ENABLE_CPP_RTTI": "YES",
             "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
@@ -80,7 +80,7 @@
       ],
 
       "libraries": [
-        "<!@(node utils/find-opencv.js --libs)"
+        "<!@(node utils/find-opencv.js --libs)",
       ],
       # For windows
 
@@ -96,7 +96,7 @@
       "conditions": [
         [ "OS==\"linux\"", {
             "cflags": [
-              "<!@(pkg-config --cflags \"opencv >= 2.3.1\" )",
+              "<!@(node utils/find-opencv.js --cflags)",
               "-Wall"
             ]
         }],
@@ -121,7 +121,7 @@
               "-mmacosx-version-min=10.7",
             "-std=c++11",
             "-stdlib=libc++",
-            "<!@(pkg-config --cflags opencv)"
+            "<!@(node utils/find-opencv.js --cflags)",
               ],
             "GCC_ENABLE_CPP_RTTI": "YES",
             "GCC_ENABLE_CPP_EXCEPTIONS": "YES"

--- a/examples/dissimilarity.js
+++ b/examples/dissimilarity.js
@@ -1,5 +1,10 @@
 var cv = require('../lib/opencv');
 
+if (cv.ImageSimilarity === undefined) {
+  console.log('TODO: Please port Features2d.cc to OpenCV 3')
+  process.exit(0);
+}
+
 cv.readImage("./examples/files/car1.jpg", function(err, car1) {
   if (err) throw err;
 

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -3,7 +3,11 @@
 #include <iostream>
 #include <nan.h>
 
-#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
+#if CV_MAJOR_VERSION >= 3
+#warning TODO: port me to OpenCV 3
+#endif
+
+#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4))
 
 Nan::Persistent<FunctionTemplate> BackgroundSubtractorWrap::constructor;
 

--- a/src/BackgroundSubtractor.h
+++ b/src/BackgroundSubtractor.h
@@ -1,6 +1,6 @@
 #include "OpenCV.h"
 
-#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
+#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4))
 
 #include <opencv2/video/background_segm.hpp>
 

--- a/src/Calib3D.h
+++ b/src/Calib3D.h
@@ -3,6 +3,10 @@
 
 #include "OpenCV.h"
 
+#if CV_MAJOR_VERSION >= 3
+#include <opencv2/calib3d.hpp>
+#endif
+
 /**
  * Implementation of calib3d.hpp functions
  */

--- a/src/CamShift.cc
+++ b/src/CamShift.cc
@@ -2,6 +2,9 @@
 #include "OpenCV.h"
 #include "Matrix.h"
 
+#if CV_MAJOR_VERSION >= 3
+#include <opencv2/video/tracking.hpp>
+#endif
 
 #define CHANNEL_HUE 0
 #define CHANNEL_SATURATION 1

--- a/src/CascadeClassifierWrap.h
+++ b/src/CascadeClassifierWrap.h
@@ -1,4 +1,7 @@
 #include "OpenCV.h"
+#if CV_MAJOR_VERSION >= 3
+#include <opencv2/objdetect.hpp>
+#endif
 
 class CascadeClassifierWrap: public Nan::ObjectWrap {
 public:

--- a/src/FaceRecognizer.cc
+++ b/src/FaceRecognizer.cc
@@ -1,7 +1,11 @@
 #include "FaceRecognizer.h"
 #include "OpenCV.h"
 
-#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4) && (CV_SUBMINOR_VERSION>=4))
+#if CV_MAJOR_VERSION >= 3
+#warning TODO: port me to OpenCV 3
+#endif
+
+#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4) && (CV_SUBMINOR_VERSION>=4))
 
 #include "Matrix.h"
 #include <nan.h>

--- a/src/FaceRecognizer.h
+++ b/src/FaceRecognizer.h
@@ -1,6 +1,6 @@
 #include "OpenCV.h"
 
-#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
+#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4) && (CV_SUBMINOR_VERSION>=4))
 
 #include "opencv2/contrib/contrib.hpp"
 

--- a/src/Features2d.cc
+++ b/src/Features2d.cc
@@ -1,9 +1,10 @@
+#include "OpenCV.h"
+
+#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4))
 #include "Features2d.h"
 #include "Matrix.h"
 #include <nan.h>
 #include <stdio.h>
-
-#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
 
 void Features::Init(Local<Object> target) {
   Nan::HandleScope scope;

--- a/src/Features2d.h
+++ b/src/Features2d.h
@@ -1,6 +1,6 @@
 #include "OpenCV.h"
 
-#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
+#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4))
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/features2d/features2d.hpp>

--- a/src/LDAWrap.cc
+++ b/src/LDAWrap.cc
@@ -1,8 +1,11 @@
-#include "LDAWrap.h"
 #include "OpenCV.h"
 
-#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4) && (CV_SUBMINOR_VERSION>=4))
+#if CV_MAJOR_VERSION >= 3
+#warning TODO: port me to OpenCV 3
+#endif
 
+#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4) && (CV_SUBMINOR_VERSION>=4))
+#include "LDAWrap.h"
 #include "Matrix.h"
 #include <nan.h>
 

--- a/src/LDAWrap.h
+++ b/src/LDAWrap.h
@@ -1,6 +1,6 @@
 #include "OpenCV.h"
 
-#if ((CV_MAJOR_VERSION >= 2) && (CV_MINOR_VERSION >=4))
+#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4))
 
 #include "opencv2/contrib/contrib.hpp"
 

--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -18,6 +18,11 @@
 #include <node_buffer.h>
 #include <opencv/cv.h>
 #include <opencv/highgui.h>
+#if CV_MAJOR_VERSION >= 3
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
+#endif
 #include <string.h>
 #include <nan.h>
 

--- a/src/Stereo.cc
+++ b/src/Stereo.cc
@@ -1,4 +1,11 @@
+
 #include "Stereo.h"
+
+#if CV_MAJOR_VERSION >= 3
+#warning TODO: port me to OpenCV 3
+#endif
+
+#if CV_MAJOR_VERSION < 3
 #include "Matrix.h"
 #include <opencv2/legacy/legacy.hpp>
 
@@ -312,3 +319,5 @@ NAN_METHOD(StereoGC::Compute) {
     return;
   }
 }
+
+#endif

--- a/src/Stereo.h
+++ b/src/Stereo.h
@@ -3,6 +3,8 @@
 
 #include "OpenCV.h"
 
+#if CV_MAJOR_VERSION < 3
+
 class StereoBM: public Nan::ObjectWrap {
 public:
   cv::StereoBM stereo;
@@ -51,3 +53,4 @@ public:
 };
 
 #endif
+#endif // __NODE_STEREO_H

--- a/src/init.cc
+++ b/src/init.cc
@@ -30,15 +30,18 @@ extern "C" void init(Local<Object> target) {
   Constants::Init(target);
   Calib3D::Init(target);
   ImgProc::Init(target);
+#if CV_MAJOR_VERSION < 3
   StereoBM::Init(target);
   StereoSGBM::Init(target);
   StereoGC::Init(target);
-
-#if CV_MAJOR_VERSION >= 2 && CV_MINOR_VERSION >=4
+#if CV_MAJOR_VERSION == 2 && CV_MINOR_VERSION >=4
   BackgroundSubtractorWrap::Init(target);
   Features::Init(target);
-  FaceRecognizerWrap::Init(target);
   LDAWrap::Init(target);
+#if CV_SUBMINOR_VERSION>=4
+  FaceRecognizerWrap::Init(target);
+#endif
+#endif
 #endif
 };
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -315,6 +315,12 @@ test("fonts", function(t) {
 })
 
 test('LDA Wrap', function(assert) {
+  if (cv.LDA === undefined) {
+    console.log('TODO: Please port LDAWrap.cc to OpenCV 3')
+    assert.end();
+    return;
+  }
+
   // subspaceProject
   var mat = cv.LDA.subspaceProject(new cv.Matrix(1, 2, cv.Constants.CV_64F), new cv.Matrix(), new cv.Matrix(2, 1, cv.Constants.CV_8UC1));
   assert.deepEqual(mat.size(), [2,2], 'subspaceProject');

--- a/utils/find-opencv.js
+++ b/utils/find-opencv.js
@@ -1,16 +1,24 @@
+"use strict";
+
 var exec = require("child_process").exec;
 var fs = require("fs");
-var flag = process.argv[2];
+var flag = process.argv[2] || "--exists";
+
+// Normally |pkg-config opencv ...| could report either OpenCV 2.x or OpenCV 3.y
+// depending on what is installed.  To enable both 2.x and 3.y to co-exist on
+// the same machine, the opencv.pc for 3.y can be installed as opencv3.pc and
+// then selected by |export PKG_CONFIG_OPENCV3=1| before building node-opencv.
+var opencv = process.env.PKG_CONFIG_OPENCV3 === "1" ? "opencv3" : '"opencv >= 2.3.1"';
 
 function main(){
     //Try using pkg-config, but if it fails and it is on Windows, try the fallback
-    exec("pkg-config opencv " + flag, function(error, stdout, stderr){
+    exec("pkg-config " + opencv + " " + flag, function(error, stdout, stderr){
         if(error){
             if(process.platform === "win32"){
                 fallback();
             }
             else{
-                throw new Error("ERROR: pkg-config couldn't find OpenCV");
+                throw new Error("ERROR: failed to run: pkg-config", opencv, flag);
             }
         }
         else{


### PR DESCRIPTION
This is semi-based on #259.   The differences are:
1. I made no attempt to port Stereo.cc here, it's just disabled in OpenCV 3
2. Other files that gave trouble in OpencCV 3 due to API changes are disabled as well: Features2d.cc, BackgroundSubtractor.cc, FaceRecognizer.cc, LDAWrap.cc.
3. Tests are passing for OpenCV 2 and 3.  Two tests will decline to run on an OpenCV 3-backed node-opencv until (2) is resolved.

The intent just to land support to get node-opencv building with OpenCV 3, at which point folks who have an interest in the disabled features in (1) and (2) can send PRs to help complete the OpenCV 3 port.

We also need to add OpenCV 3 to Travis but that's also for a follow-up PR.