### PR TITLE
Export node-opencv Matrix constructor to native code

### DIFF
--- a/inc/Matrix.h
+++ b/inc/Matrix.h
@@ -23,6 +23,28 @@ protected:
   Matrix(): Nan::ObjectWrap() {};
 };
 
+#ifdef WIN32
+inline Nan::Persistent<v8::FunctionTemplate> *Matrix_Ctor() {
+  Nan::ThrowError("Sry, Windows not supported yet");
+  return NULL;
+}
+#else
+#include <dlfcn.h>
+inline Nan::Persistent<v8::FunctionTemplate> *Matrix_Ctor() {
+  void *handle = dlopen("opencv.node", RTLD_LAZY | RTLD_NOLOAD);
+  if (handle) {
+    // Obtain a pointer to Matrix::constructor
+    Nan::Persistent<v8::FunctionTemplate>* constructor =
+      static_cast<Nan::Persistent<v8::FunctionTemplate>*>(dlsym(handle, "_ZN6Matrix11constructorE"));
+    dlclose(handle);
+    if (constructor) {
+      return constructor;
+    }
+  }
+  return NULL;
+}
+#endif
+
 }
 
 #endif // NODE_OPENCV_MATRIX_H

--- a/test/nativemat.cc
+++ b/test/nativemat.cc
@@ -12,9 +12,28 @@ void Size(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   info.GetReturnValue().Set(arr);
 }
 
+void Zeros(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  int w = info[0]->Uint32Value();
+  int h = info[1]->Uint32Value();
+
+  v8::Local<v8::Object> obj =
+      Nan::New(*node_opencv::Matrix_Ctor())->GetFunction()->NewInstance();
+  node_opencv::Matrix *mat = Nan::ObjectWrap::Unwrap<node_opencv::Matrix>(obj);
+
+  mat->mat = cv::Mat::zeros(w, h, CV_64FC1);
+
+  info.GetReturnValue().Set(obj);
+}
+
+
+
 void Init(v8::Local<v8::Object> exports) {
   exports->Set(Nan::New("size").ToLocalChecked(),
                Nan::New<v8::FunctionTemplate>(Size)->GetFunction());
+#ifndef WIN32 // Skip on Windows for now (see inc/Matrix.h)
+  exports->Set(Nan::New("zeros").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Zeros)->GetFunction());
+#endif
 }
 
 NODE_MODULE(test_nativemat, Init)

--- a/test/unit.js
+++ b/test/unit.js
@@ -336,8 +336,15 @@ test('LDA Wrap', function(assert) {
 test('Native Matrix', function(assert) {
   var nativemat = require('../build/Release/test_nativemat.node');
   var mat = new cv.Matrix(42, 8);
+  assert.deepEqual(mat.size(), nativemat.size(mat), 'nativemat size match');
 
-  assert.deepEqual(mat.size(), nativemat.size(mat), 'nativemat');
+  if (nativemat.zeros) { // Skip on Windows for now (see inc/Matrix.h)
+    var newmat = nativemat.zeros(2, 3);
+    assert.deepEqual(newmat.size(), [2, 3], 'new nativemat size');
+    assert.deepEqual(newmat.row(0), [0, 0, 0], 'new nativemat row 0');
+    assert.deepEqual(newmat.row(1), [0, 0, 0], 'new nativemat row 1');
+  }
+
   assert.end();
 })
 


### PR DESCRIPTION
Like #359 but the other way around. This enables other native code to create node-opencv-compatible Matrices.
