### PR TITLE
type_info error

### DIFF
--- a/src/Contours.cc
+++ b/src/Contours.cc
@@ -75,7 +75,7 @@ NAN_METHOD(Contour::Points) {
   Contour *self = Nan::ObjectWrap::Unwrap<Contour>(info.This());
   int pos = info[0]->NumberValue();
 
-  vector<cv::Point> points = self->contours[pos];
+  std::vector<cv::Point> points = self->contours[pos];
   Local<Array> data = Nan::New<Array>(points.size());
 
   for (std::vector<int>::size_type i = 0; i != points.size(); i++) {
@@ -295,7 +295,7 @@ NAN_METHOD(Contour::Serialize) {
   Local<Array> contours_data = Nan::New<Array>(self->contours.size());
 
   for (std::vector<int>::size_type i = 0; i != self->contours.size(); i++) {
-    vector<cv::Point> points = self->contours[i];
+	  std::vector<cv::Point> points = self->contours[i];
     Local<Array> contour_data = Nan::New<Array>(points.size());
 
     for (std::vector<int>::size_type j = 0; j != points.size(); j++) {
@@ -336,12 +336,12 @@ NAN_METHOD(Contour::Deserialize) {
   Local<Array> contours_data = Local<Array>::Cast(data->Get(Nan::New<String>("contours").ToLocalChecked()));
   Local<Array> hierarchy_data = Local<Array>::Cast(data->Get(Nan::New<String>("hierarchy").ToLocalChecked()));
 
-  vector<vector<cv::Point> > contours_res;
+  std::vector<std::vector<cv::Point> > contours_res;
   int contours_length = contours_data->Length();
 
   for (int i = 0; i < contours_length; i++) {
     Local<Array> contour_data = Local<Array>::Cast(contours_data->Get(i));
-    vector<cv::Point> points;
+	std::vector<cv::Point> points;
 
     int contour_length = contour_data->Length();
     for (int j = 0; j < contour_length; j++) {
@@ -354,7 +354,7 @@ NAN_METHOD(Contour::Deserialize) {
     contours_res.push_back(points);
   }
 
-  vector<cv::Vec4i> hierarchy_res;
+  std::vector<cv::Vec4i> hierarchy_res;
   int hierarchy_length = hierarchy_data->Length();
 
   for (int i = 0; i < hierarchy_length; i++) {

--- a/src/Contours.cc
+++ b/src/Contours.cc
@@ -295,7 +295,7 @@ NAN_METHOD(Contour::Serialize) {
   Local<Array> contours_data = Nan::New<Array>(self->contours.size());
 
   for (std::vector<int>::size_type i = 0; i != self->contours.size(); i++) {
-	  std::vector<cv::Point> points = self->contours[i];
+    std::vector<cv::Point> points = self->contours[i];
     Local<Array> contour_data = Nan::New<Array>(points.size());
 
     for (std::vector<int>::size_type j = 0; j != points.size(); j++) {
@@ -341,7 +341,7 @@ NAN_METHOD(Contour::Deserialize) {
 
   for (int i = 0; i < contours_length; i++) {
     Local<Array> contour_data = Local<Array>::Cast(contours_data->Get(i));
-	std::vector<cv::Point> points;
+    std::vector<cv::Point> points;
 
     int contour_length = contour_data->Length();
     for (int j = 0; j < contour_length; j++) {

--- a/src/Contours.h
+++ b/src/Contours.h
@@ -1,12 +1,11 @@
 #include "OpenCV.h"
 
-using namespace std;
 
 class Contour: public Nan::ObjectWrap {
 public:
   cv::Mat mat;
-  vector<vector<cv::Point> > contours;
-  vector<cv::Vec4i> hierarchy;
+  std::vector<std::vector<cv::Point> > contours;
+  std::vector<cv::Vec4i> hierarchy;
 
   static Nan::Persistent<FunctionTemplate> constructor;
   static void Init(Local<Object> target);

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -669,7 +669,7 @@ NAN_METHOD(Matrix::ToBuffer) {
 class AsyncToBufferWorker: public Nan::AsyncWorker {
 public:
   AsyncToBufferWorker(Nan::Callback *callback, Matrix* matrix, std::string ext,
-	  std::vector<int> params) :
+    std::vector<int> params) :
       Nan::AsyncWorker(callback),
       matrix(matrix),
       ext(ext),
@@ -2203,13 +2203,13 @@ NAN_METHOD(Matrix::TemplateMatches) {
       int max_x = maxSize.width - 1;
       int max_y = maxSize.height - 1;
       cv::Point top_left = cv::Point(std::max(0, pt.x - min_x_distance),
-		  std::max(0, pt.y - min_y_distance));
+        std::max(0, pt.y - min_y_distance));
       cv::Point top_right = cv::Point(std::min(max_x, pt.x + min_x_distance),
-		  std::max(0, pt.y - min_y_distance));
+        std::max(0, pt.y - min_y_distance));
       cv::Point bottom_left = cv::Point(std::max(0, pt.x - min_x_distance),
-		  std::min(max_y, pt.y + min_y_distance));
+        std::min(max_y, pt.y + min_y_distance));
       cv::Point bottom_right = cv::Point(std::min(max_x, pt.x + min_x_distance),
-		  std::min(max_y, pt.y + min_y_distance));
+        std::min(max_y, pt.y + min_y_distance));
       if (hit_mask.at<double>(top_left.y, top_left.x) > 0)
         continue;
       if (hit_mask.at<double>(top_right.y, top_right.x) > 0)

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -668,8 +668,8 @@ NAN_METHOD(Matrix::ToBuffer) {
 
 class AsyncToBufferWorker: public Nan::AsyncWorker {
 public:
-  AsyncToBufferWorker(Nan::Callback *callback, Matrix* matrix, string ext,
-      vector<int> params) :
+  AsyncToBufferWorker(Nan::Callback *callback, Matrix* matrix, std::string ext,
+	  std::vector<int> params) :
       Nan::AsyncWorker(callback),
       matrix(matrix),
       ext(ext),
@@ -2055,7 +2055,7 @@ NAN_METHOD(Matrix::Split) {
   Matrix * self = Nan::ObjectWrap::Unwrap<Matrix>(info.This());
 
   unsigned int size = self->mat.channels();
-  vector<cv::Mat> channels;
+  std::vector<cv::Mat> channels;
 
   // Split doesn't seem to work on empty vectors
   for (unsigned int i = 0; i < size; i++) {
@@ -2088,7 +2088,7 @@ NAN_METHOD(Matrix::Merge) {
   v8::Local<v8::Array> jsChannels = v8::Local<v8::Array>::Cast(info[0]);
 
   unsigned int L = jsChannels->Length();
-  vector<cv::Mat> vChannels(L);
+  std::vector<cv::Mat> vChannels(L);
   for (unsigned int i = 0; i < L; i++) {
     Matrix * matObject = Nan::ObjectWrap::Unwrap<Matrix>(jsChannels->Get(i)->ToObject());
     vChannels[i] = matObject->mat;
@@ -2202,14 +2202,14 @@ NAN_METHOD(Matrix::TemplateMatches) {
       cv::Size maxSize = hit_mask.size();
       int max_x = maxSize.width - 1;
       int max_y = maxSize.height - 1;
-      cv::Point top_left = cv::Point(max(0, pt.x - min_x_distance),
-          max(0, pt.y - min_y_distance));
-      cv::Point top_right = cv::Point(min(max_x, pt.x + min_x_distance),
-          max(0, pt.y - min_y_distance));
-      cv::Point bottom_left = cv::Point(max(0, pt.x - min_x_distance),
-          min(max_y, pt.y + min_y_distance));
-      cv::Point bottom_right = cv::Point(min(max_x, pt.x + min_x_distance),
-          min(max_y, pt.y + min_y_distance));
+      cv::Point top_left = cv::Point(std::max(0, pt.x - min_x_distance),
+		  std::max(0, pt.y - min_y_distance));
+      cv::Point top_right = cv::Point(std::min(max_x, pt.x + min_x_distance),
+		  std::max(0, pt.y - min_y_distance));
+      cv::Point bottom_left = cv::Point(std::max(0, pt.x - min_x_distance),
+		  std::min(max_y, pt.y + min_y_distance));
+      cv::Point bottom_right = cv::Point(std::min(max_x, pt.x + min_x_distance),
+		  std::min(max_y, pt.y + min_y_distance));
       if (hit_mask.at<double>(top_left.y, top_left.x) > 0)
         continue;
       if (hit_mask.at<double>(top_right.y, top_right.x) > 0)

--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -3,7 +3,6 @@
 #include "OpenCV.h"
 
 #include  <iostream>
-using namespace std;
 
 Nan::Persistent<FunctionTemplate> VideoCaptureWrap::constructor;
 


### PR DESCRIPTION
Changes to correct type_info errors seen in Visual Studio from std namespace pollution. Removed global std namespace references and specifically prefixed each call.