### PR TITLE
Add ending capability to ImageStream

### DIFF
--- a/lib/opencv.js
+++ b/lib/opencv.js
@@ -36,18 +36,37 @@ Matrix.prototype.inspect = function(){
 
 ImageStream = cv.ImageStream = function(){
   this.writable = true;
+  this.tailPromise = Promise.resolve();
 }
 util.inherits(ImageStream, Stream);
 
 
+ImageStream.prototype.end = function(){
+  var self = this;
+  this.tailPromise.then(function() {
+    self.emit('finish');
+  });
+};
+
 ImageStream.prototype.write = function(buf){
   var self = this;
-  cv.readImage(buf, function(err, matrix){
-    if (err) return self.emit('error', err);
-    self.emit('data', matrix);
+  var prom = new Promise(function(resolve, reject) {
+    cv.readImage(buf, function(err, matrix){
+      if (err) {
+        process.nextTick(function () {
+          reject(err)
+        });
+        return self.emit('error', err);
+      }
+      self.emit('data', matrix);
+      process.nextTick(resolve);
+    });
+  });
+  // new tail promise
+  this.tailPromise = this.tailPromise.then(function() {
+    return prom;
   });
 }
-
 
 ImageDataStream = cv.ImageDataStream = function(){
   this.data = Buffers([]);


### PR DESCRIPTION
Hello, I was trying to wrap ImageStream inside another duplex stream and found it helpful to have a `.end` method even though ImageStream isn't a full transform stream. 

Would this be helpful to anyone out there? 

Here's an example of making a duplex stream module with ImageStream. The key thing this adds is the `finish` event so the readable (output) side of the module can end once image processing is done:

[example gist](https://gist.github.com/johnelliott/12f4d5f7ea4c09e618dc4e66c9aefe3f)

```javascript
module.exports = function() {
  var cvStream = new cv.ImageStream();
  var output = through();

  input.pipe(cvStream);

  cvStream.on('finish', function() {
    output.end();
  });

  cvStream.on('data', function(im) {
    im.detectObject('node_modules/opencv/data/haarcascade_fullbody.xml', {}, function(err, matches) {
      if (err) { ... }
      output.write(JSON.stringify(match));
      }
    });
  });
  return duplex(input, output);
};
```
This PR relies on native promises, but a promise lib or some other form of accounting could go in place.