### PR TITLE
AsyncSaveWorker now controls the lifecycle of its filename

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -982,7 +982,7 @@ public:
 
 private:
   Matrix* matrix;
-  char* filename;
+  std::string filename;
   int res;
 };
 


### PR DESCRIPTION
One-liner that prevents AsyncSaveWorker from using de-allocated memory