### PR TITLE
Add matrix mean method

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -106,6 +106,7 @@ void Matrix::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "copyWithMask", CopyWithMask);
   Nan::SetPrototypeMethod(ctor, "setWithMask", SetWithMask);
   Nan::SetPrototypeMethod(ctor, "meanWithMask", MeanWithMask);
+  Nan::SetPrototypeMethod(ctor, "mean", Mean);
   Nan::SetPrototypeMethod(ctor, "shift", Shift);
   Nan::SetPrototypeMethod(ctor, "reshape", Reshape);
   Nan::SetPrototypeMethod(ctor, "release", Release);
@@ -2484,10 +2485,24 @@ NAN_METHOD(Matrix::MeanWithMask) {
   Matrix *mask = Nan::ObjectWrap::Unwrap<Matrix>(info[0]->ToObject());
 
   cv::Scalar means = cv::mean(self->mat, mask->mat);
-  v8::Local < v8::Array > arr = Nan::New<Array>(3);
+  v8::Local < v8::Array > arr = Nan::New<Array>(4);
   arr->Set(0, Nan::New<Number>(means[0]));
   arr->Set(1, Nan::New<Number>(means[1]));
   arr->Set(2, Nan::New<Number>(means[2]));
+  arr->Set(3, Nan::New<Number>(means[3]));
+
+  info.GetReturnValue().Set(arr);
+}
+
+NAN_METHOD(Matrix::Mean) {
+  SETUP_FUNCTION(Matrix)
+
+  cv::Scalar means = cv::mean(self->mat);
+  v8::Local<v8::Array> arr = Nan::New<Array>(4);
+  arr->Set(0, Nan::New<Number>(means[0]));
+  arr->Set(1, Nan::New<Number>(means[1]));
+  arr->Set(2, Nan::New<Number>(means[2]));
+  arr->Set(3, Nan::New<Number>(means[3]));
 
   info.GetReturnValue().Set(arr);
 }

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -121,6 +121,7 @@ public:
   JSFUNC(CopyWithMask)
   JSFUNC(SetWithMask)
   JSFUNC(MeanWithMask)
+  JSFUNC(Mean)
   JSFUNC(Shift)
   JSFUNC(Reshape)
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -351,6 +351,19 @@ test('Subtract', function(assert) {
   assert.end();
 });
 
+test('Mean', function(assert) {
+  var a = new cv.Matrix.Zeros(2, 2, cv.Constants.CV_8UC3);
+
+  // Set [0, 0] element to 1 for all three channels
+  a.set(0, 0, 1, 0);
+  a.set(0, 0, 1, 1);
+  a.set(0, 0, 1, 2);
+
+  var means = a.mean();
+  assert.deepEqual(means, [0.25, 0.25, 0.25, 0]);
+  assert.end();
+});
+
 // Test the examples folder.
 require('./examples')()
 


### PR DESCRIPTION
@mvines ?
@peterbraden ?

I see there is a `meanWithMask` method already available. Ideally there should only be one `mean` method with an optional argument of mask. There are a bunch of other such withMask methods so may be as a separate PR I would consolidate them.