### PR TITLE
fix dissimilarity example

### DIFF
--- a/examples/dissimilarity.js
+++ b/examples/dissimilarity.js
@@ -5,10 +5,10 @@ if (cv.ImageSimilarity === undefined) {
   process.exit(0);
 }
 
-cv.readImage("./examples/files/car1.jpg", function(err, car1) {
+cv.readImage("./files/car1.jpg", function(err, car1) {
   if (err) throw err;
 
-  cv.readImage("./examples/files/car2.jpg", function(err, car2) {
+  cv.readImage("./files/car2.jpg", function(err, car2) {
     if (err) throw err;
 
     cv.ImageSimilarity(car1, car2, function (err, dissimilarity) {


### PR DESCRIPTION
The dissimilarity example was linking to the wrong path for the car images. This was mentioned in #264. Looking at the concerns raised in #264, I'd guess most peoples problem is trying to process empty images.