### PR TITLE
Update node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "buffers": "^0.1.1",
     "nan": "^2.0.9",
-    "node-pre-gyp": "^0.6.11"
+    "node-pre-gyp": "^0.6.30"
   },
   "devDependencies": {
     "tape": "^3.0.0",


### PR DESCRIPTION
The older `node-pre-gyp` `0.6.11` version prevented proper handling of electron runtime (as discussed in https://github.com/mapbox/node-pre-gyp/pull/175). [bindings.js](https://github.com/peterbraden/node-opencv/blob/master/lib/bindings.js#L3) can't resolve the proper build path for electron. Updating to `0.6.30` fixes the issue.

Resolves #430 