### PR TITLE
Rename video capture close to release

### DIFF
--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -33,7 +33,7 @@ void VideoCaptureWrap::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "setPosition", SetPosition);
   Nan::SetPrototypeMethod(ctor, "getFrameAt", GetFrameAt);
   Nan::SetPrototypeMethod(ctor, "getFrameCount", GetFrameCount);
-  Nan::SetPrototypeMethod(ctor, "close", Close);
+  Nan::SetPrototypeMethod(ctor, "release", Release);
   Nan::SetPrototypeMethod(ctor, "ReadSync", ReadSync);
   Nan::SetPrototypeMethod(ctor, "grab", Grab);
   Nan::SetPrototypeMethod(ctor, "retrieve", Retrieve);
@@ -145,7 +145,7 @@ NAN_METHOD(VideoCaptureWrap::GetFrameAt) {
   return;
 }
 
-NAN_METHOD(VideoCaptureWrap::Close) {
+NAN_METHOD(VideoCaptureWrap::Release) {
   Nan::HandleScope scope;
   VideoCaptureWrap *v = Nan::ObjectWrap::Unwrap<VideoCaptureWrap>(info.This());
 

--- a/src/VideoCaptureWrap.h
+++ b/src/VideoCaptureWrap.h
@@ -27,7 +27,6 @@ public:
 
   static NAN_METHOD(GetFrameAt);
 
-  //close the stream
-  static NAN_METHOD(Close);
+  // release the stream
+  static NAN_METHOD(Release);
 };
-


### PR DESCRIPTION
This follows [opencv documentation](http://docs.opencv.org/3.1.0/d8/dfe/classcv_1_1VideoCapture.html#afb4ab689e553ba2c8f0fec41b9344ae6) better. In addition to #99.

This is a breaking change.