### PR TITLE
Code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out*.png
 examples/*.avi
 examples/tmp/*
 vagrant/.vagrant
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_install:
   - sudo add-apt-repository -y ppa:kubuntu-ppa/backports
   - sudo apt-get update
   - sudo apt-get install --force-yes --yes libcv-dev libcvaux-dev libhighgui-dev libopencv-dev
+  # for code coverage
+  - sudo apt-get install lcov
   # get commit message
   - COMMIT_MESSAGE=$(git show -s --format=%B $TRAVIS_COMMIT | tr -d '\n')
   # put local node-pre-gyp on PATH
@@ -49,11 +51,11 @@ before_install:
   - platform=$(uname -s | sed "y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/")
 
 install:
-  # ensure source install works
-  - npm install --build-from-source
-  # test our module
-  - npm test
-  - node lib/opencv.js
+  # install dependencies first
+  - npm install
+  # build from source, run test and generate code coverage
+  - make cover
+  - DEBUG=true node lib/opencv.js
   - docker build -t peterbraden/node-opencv-ubuntu-12-04 -f test/Dockerfile-ubuntu-12-04 .
   - docker build -t peterbraden/node-opencv-ubuntu-14-04 -f test/Dockerfile-ubuntu-14-04 .
 
@@ -81,3 +83,5 @@ script:
 after_success:
   # if success then query and display all published binaries
   - node-pre-gyp info
+  # Upload coverage to codecov
+  - bash <(curl -s https://codecov.io/bash) -s coverage -f *.info

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -68,3 +68,4 @@ Ordered by date of first contribution. [Auto-generated](https://github.com/xingr
 - [vyacheslav](https://github.com/vyacheslav-lonschakov)
 - vyacheslav
 - [Harold Ozouf](https://github.com/jspdown)
+- [Dan Schultzer](https://github.com/danschultzer)

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,63 @@ travis-build:
 	docker build -t peterbraden/node-opencv-ubuntu-12-04 -f test/Dockerfile-ubuntu-12-04 .
 	docker build -t peterbraden/node-opencv-ubuntu-14-04 -f test/Dockerfile-ubuntu-14-04 .
 .PHONY: travis-build
+
+
+# Below build, coverage and clean tasks were partly lifted from https://github.com/geo-data/node-mapserv/blob/e99b23a44d910d444f5a45d144859758f820e1d1/Makefile
+# @author danschultzer
+
+# The location of the `istanbul` JS code coverage framework. Try and get a
+# globally installed version, falling back to a local install.
+ISTANBUL := $(shell which istanbul)
+ifeq ($(ISTANBUL),)
+	ISTANBUL = ./node_modules/.bin/istanbul/lib/cli.js
+endif
+
+# The location of the `node-pre-gyp` module builder. Try and get a globally
+# installed version, falling back to a local install.
+NODE_PRE_GYP = $(shell which node-pre-gyp)
+ifeq ($(NODE_GYP),)
+	NODE_PRE_GYP = ./node_modules/.bin/node-pre-gyp
+endif
+
+NODE := $(shell which node)
+test_deps = build \
+./test/*.js \
+./lib/*.js \
+$(NODE)
+
+build: build/Debug/opencv.node
+build/Debug/opencv.node:
+	$(NODE_PRE_GYP) --verbose --debug rebuild
+
+# Perform the code coverage
+cover: coverage/index.html
+coverage/index.html: coverage/node-opencv.info
+	genhtml --output-directory coverage coverage/node-opencv.info
+	@echo "\033[0;32mPoint your browser at \`coverage/index.html\`\033[m\017"
+coverage/node-opencv.info: coverage/bindings.info
+	lcov --test-name node-opencv \
+	--add-tracefile coverage/lcov.info \
+	--add-tracefile coverage/bindings.info \
+	--output-file coverage/node-opencv.info
+coverage/bindings.info: coverage/addon.info
+	lcov --extract coverage/addon.info '*opencv/src/*' --output-file coverage/bindings.info
+coverage/addon.info: coverage/lcov.info
+	lcov --capture --base-directory build/ --directory . --output-file coverage/addon.info
+# This generates the JS lcov info as well as gcov `*.gcda` files:
+coverage/lcov.info: $(test_deps) $(ISTANBUL)
+	DEBUG=true $(NODE) --nouse_idle_notification --expose-gc \
+	$(ISTANBUL) cover --report lcovonly -- test/unit.js
+
+$(NODE_PRE_GYP):
+	npm install node-pre-gyp
+
+$(ISTANBUL): package.json
+	npm install istanbul
+	@touch $(ISTANBUL)
+
+# Clean up any generated files
+clean: $(NODE_PRE_GYP)
+	$(NODE_PRE_GYP) clean
+	rm -rf coverage
+	rm -rf build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # node-opencv
 
 [![Build Status](https://secure.travis-ci.org/peterbraden/node-opencv.png)](http://travis-ci.org/peterbraden/node-opencv)
-
+[![Coverage](http://codecov.io/github/peterbraden/node-opencv/coverage.svg?branch=master)](https://codecov.io/gh/peterbraden/node-opencv)
 
 [OpenCV](http://opencv.org) bindings for Node.js. OpenCV is
 the defacto computer vision library - by interfacing with it natively in node,
@@ -222,6 +222,20 @@ contours.fitEllipse(index);
 contours.approxPolyDP(index, epsilon, isClosed);
 contours.convexHull(index, clockwise);
 ```
+
+## Test
+
+Using [tape](https://github.com/substack/tape). Run with command:
+
+`npm test`.
+
+## Code coverage
+
+Using [istanbul](http://gotwarlost.github.io/istanbul/) and [lcov](http://ltp.sourceforge.net/coverage/lcov.php). Run with command:
+
+`make cover`
+
+Build version of `opencv.node` will be generated, and coverage files will be put in `coverage/` directory. These files can be remvoved automatically by running `make clean`.
 
 ## MIT License
 The library is distributed under the MIT License - if for some reason that

--- a/binding.gyp
+++ b/binding.gyp
@@ -62,15 +62,31 @@
             "xcode_settings": {
             "OTHER_CFLAGS": [
               "-mmacosx-version-min=10.7",
-            "-std=c++11",
-            "-stdlib=libc++",
-            "<!@(node utils/find-opencv.js --cflags)",
-              ],
+              " -fprofile-arcs -ftest-coverage ",
+              "-std=c++11",
+              "-stdlib=libc++",
+              "<!@(node utils/find-opencv.js --cflags)",
+            ],
+            "OTHER_LDFLAGS": [
+              "--coverage"
+            ],
             "GCC_ENABLE_CPP_RTTI": "YES",
             "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
           }
         }]
-    ]
+    ],
+
+    "configurations": {
+        # This is used for generating code coverage with the `--debug` argument
+        "Debug": {
+          "conditions": [
+            ['OS=="linux"', {
+              "cflags": ["-coverage"],
+              "ldflags": ["-coverage"]
+            }]
+          ]
+        },
+    }
   },
   {
       "target_name": "test_nativemat",
@@ -119,10 +135,10 @@
             "xcode_settings": {
             "OTHER_CFLAGS": [
               "-mmacosx-version-min=10.7",
-            "-std=c++11",
-            "-stdlib=libc++",
-            "<!@(node utils/find-opencv.js --cflags)",
-              ],
+              "-std=c++11",
+              "-stdlib=libc++",
+              "<!@(node utils/find-opencv.js --cflags)",
+            ],
             "GCC_ENABLE_CPP_RTTI": "YES",
             "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
           }

--- a/binding.gyp
+++ b/binding.gyp
@@ -60,20 +60,17 @@
         [ # cflags on OS X are stupid and have to be defined like this
           "OS==\"mac\"", {
             "xcode_settings": {
-            "OTHER_CFLAGS": [
-              "-mmacosx-version-min=10.7",
-              " -fprofile-arcs -ftest-coverage ",
-              "-std=c++11",
-              "-stdlib=libc++",
-              "<!@(node utils/find-opencv.js --cflags)",
-            ],
-            "OTHER_LDFLAGS": [
-              "--coverage"
-            ],
-            "GCC_ENABLE_CPP_RTTI": "YES",
-            "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+              "OTHER_CFLAGS": [
+                "-mmacosx-version-min=10.7",
+                "-std=c++11",
+                "-stdlib=libc++",
+                "<!@(node utils/find-opencv.js --cflags)",
+              ],
+              "GCC_ENABLE_CPP_RTTI": "YES",
+              "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+            }
           }
-        }]
+        ]
     ],
 
     "configurations": {
@@ -83,7 +80,18 @@
             ['OS=="linux"', {
               "cflags": ["-coverage"],
               "ldflags": ["-coverage"]
+            }],
+            ['OS=="mac"', {
+              "xcode_settings": {
+                "OTHER_CFLAGS": [
+                  "-fprofile-arcs -ftest-coverage",
+                ],
+                "OTHER_LDFLAGS": [
+                  "--coverage"
+                ]
+              }
             }]
+
           ]
         },
     }

--- a/examples/test.js
+++ b/examples/test.js
@@ -1,6 +1,5 @@
 var cv = require('../lib/opencv');
 
-var mat = new cv.Matrix(1, 2, cv.Constants.CV_8U, [1]);
+var mat = new cv.Matrix(1, 2, cv.Constants.CV_8UC3, [1]);
 var row = mat.pixelRow(0);
 console.log("mat: " + row[0] + row[1]);
-

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -1,6 +1,6 @@
 var binary = require('node-pre-gyp');
 var path = require('path');
-var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
+var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')), { debug: !!process.env.DEBUG });
 var binding = require(binding_path);
 
 //module.exports = require('../build/Release/opencv.node');

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Peter Braden <peterbraden@peterbraden.co.uk>",
   "dependencies": {
     "buffers": "^0.1.1",
+    "istanbul": "0.4.5",
     "nan": "^2.0.9",
     "node-pre-gyp": "^0.6.30"
   },

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -198,7 +198,7 @@ double Matrix::DblGet(cv::Mat mat, int i, int j) {
 
   switch (mat.type()) {
     case CV_32FC3:
-      pix = mat.at<cv::Vec3b>(i, j);
+      pix = mat.at<cv::Vec3f>(i, j);
       pint |= (uchar) pix.val[2];
       pint |= ((uchar) pix.val[1]) << 8;
       pint |= ((uchar) pix.val[0]) << 16;
@@ -281,9 +281,9 @@ NAN_METHOD(Matrix::Set) {
     switch (self->mat.type()) {
       case CV_32FC3:
         vint = static_cast<unsigned int>(val + 0.5);
-        self->mat.at<cv::Vec3b>(i, j)[0] = (uchar) (vint >> 16) & 0xff;
-        self->mat.at<cv::Vec3b>(i, j)[1] = (uchar) (vint >> 8) & 0xff;
-        self->mat.at<cv::Vec3b>(i, j)[2] = (uchar) (vint) & 0xff;
+        self->mat.at<cv::Vec3f>(i, j)[0] = (uchar) (vint >> 16) & 0xff;
+        self->mat.at<cv::Vec3f>(i, j)[1] = (uchar) (vint >> 8) & 0xff;
+        self->mat.at<cv::Vec3f>(i, j)[2] = (uchar) (vint) & 0xff;
         // printf("!!!i %x, %x, %x", (vint >> 16) & 0xff, (vint >> 8) & 0xff, (vint) & 0xff);
         break;
       default:

--- a/test/unit.js
+++ b/test/unit.js
@@ -61,8 +61,8 @@ test('Matrix constructor', function(assert){
 
 test('Matrix accessors', function(assert){
   var mat = new cv.Matrix(1, 2);
-  mat.set(0,0,3)
-  mat.set(0,1,5000)
+  mat.set(0,0,3);
+  mat.set(0,1,5000);
   assert.deepEqual(mat.row(0), [3,5000]);
 
   mat = new cv.Matrix(1,2);
@@ -335,7 +335,7 @@ test('LDA Wrap', function(assert) {
 
 
 test('Native Matrix', function(assert) {
-  var nativemat = require('../build/Release/test_nativemat.node');
+  var nativemat = require('../build/' + (!!process.env.DEBUG ? 'Debug' : 'Release') + '/test_nativemat.node');
   var mat = new cv.Matrix(42, 8);
 
   assert.deepEqual(mat.size(), nativemat.size(mat), 'nativemat');


### PR DESCRIPTION
<img width="1101" alt="screen shot 2016-09-22 at 1 55 36 am" src="https://cloud.githubusercontent.com/assets/1254724/18742184/ba996012-8067-11e6-8e98-c2198d9bf8a1.png">

Adding full code coverage (.cc and .js files).

I spent way too much time on this due to my limited experience with c++ :rage1: 

To get this running on MacOS Sierra I had to modify the following line in the LCOV 1.12 package:

> /usr/local/bin/geninfo
```
1927 	$version_string = $pipe_next_line if ($pipe_next_line && $version_string =~ /LLVM/);
1928	close(GCOV_PIPE);
```
> -
```
1927 	$version_string = $pipe_next_line if ($pipe_next_line && !($version_string =~ /LLVM/));
1928	close(GCOV_PIPE);
```

Not sure if it's a bug in the lcov package 🤔 Kept getting this annoying issue where lcov was just "Scanning . for `.da` files ..." instead of `.gcda` files.

Got the inspiration for this implementation from [node-mapserv's makefile](https://github.com/geo-data/node-mapserv/blob/e99b23a44d910d444f5a45d144859758f820e1d1/Makefile).

I think it's ready for some 👀

Run `make cover` to build coverage, and `make clean` to remove all the generated stuff again.