### PR TITLE
Added copyMakeBorder function

### DIFF
--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -27,6 +27,7 @@ public:
   JSFUNC(Normalize)
   JSFUNC(Brightness)
   JSFUNC(Norm)
+  JSFUNC(CopyMakeBorder)
 
   JSFUNC(Row)
   JSFUNC(PixelRow)


### PR DESCRIPTION
This a rough first cut at adding support for [`copyMakeBorder`](http://docs.opencv.org/2.4/modules/imgproc/doc/filtering.html?highlight=copymakeborder#copymakeborder).

This is my first `node-gyp` contribution, so I'm not exactly sure how to test and such.
It does work based on local testing.
