### PR TITLE
BackgroundSubtractor: Port to OpenCV3

### DIFF
--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -4,10 +4,10 @@
 #include <nan.h>
 
 #if CV_MAJOR_VERSION >= 3
-#warning TODO: port me to OpenCV 3
+#include <opencv2/bgsegm.hpp>
 #endif
 
-#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4))
+#ifdef HAVE_BACKGROUNDSUBTRACTOR
 
 Nan::Persistent<FunctionTemplate> BackgroundSubtractorWrap::constructor;
 
@@ -34,7 +34,12 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
   }
 
   // Create MOG by default
+#if CV_MAJOR_VERSION >= 3
+  cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
+#else
   cv::Ptr<cv::BackgroundSubtractor> bg;
+#endif
+
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
   pt->Wrap(info.This());
 
@@ -58,7 +63,12 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateMOG) {
 
   Local<Object> n = Nan::New(BackgroundSubtractorWrap::constructor)->GetFunction()->NewInstance();
 
+  // FIXME: actually respect arguments passed in
+#if CV_MAJOR_VERSION >= 3
+  cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
+#else
   cv::Ptr<cv::BackgroundSubtractor> bg;
+#endif
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(n);
@@ -100,8 +110,11 @@ NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
     }
 
     cv::Mat _fgMask;
+#if CV_MAJOR_VERSION >= 3
+    self->subtractor->apply(mat, _fgMask);
+#else
     self->subtractor->operator()(mat, _fgMask);
-
+#endif
     img->mat = _fgMask;
     mat.release();
 

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -22,6 +22,7 @@ void BackgroundSubtractorWrap::Init(Local<Object> target) {
 
   Nan::SetMethod(ctor, "createMOG", CreateMOG);
   Nan::SetPrototypeMethod(ctor, "applyMOG", ApplyMOG);
+  Nan::SetPrototypeMethod(ctor, "history", History);
 
   target->Set(Nan::New("BackgroundSubtractor").ToLocalChecked(), ctor->GetFunction());
 }
@@ -133,6 +134,25 @@ NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
     Nan::ThrowError(err_msg);
     return;
   }
+}
+
+NAN_METHOD(BackgroundSubtractorWrap::History) {
+  SETUP_FUNCTION(BackgroundSubtractorWrap);
+
+#if CV_MAJOR_VERSION >= 3
+  auto mog = dynamic_cast<cv::bgsegm::BackgroundSubtractorMOG *>(self->subtractor.get());
+#else
+  auto mog = dynamic_cast<cv::BackgroundSubtractorMOG *>(self->subtractor.get());
+#endif
+  if (!mog) {
+    Nan::ThrowError("Not using a BackgroundSubtractorMOG");
+  }
+
+  if (info.Length() > 0) {
+    mog->setHistory(info[0]->NumberValue());
+  }
+
+  info.GetReturnValue().Set(mog->getHistory());
 }
 
 BackgroundSubtractorWrap::BackgroundSubtractorWrap(

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -9,6 +9,17 @@
 
 #ifdef HAVE_BACKGROUNDSUBTRACTOR
 
+
+#if CV_MAJOR_VERSION >= 3
+cv::bgsegm::BackgroundSubtractorMOG* getMOG(BackgroundSubtractorWrap *wrap) {
+  return dynamic_cast<cv::bgsegm::BackgroundSubtractorMOG *>(wrap->subtractor.get());
+}
+#else
+cv::BackgroundSubtractorMOG* getMOG(BackgroundSubtractorWrap *wrap) {
+  return dynamic_cast<cv::BackgroundSubtractorMOG *>(wrap->subtractor.get());
+}
+#endif
+
 Nan::Persistent<FunctionTemplate> BackgroundSubtractorWrap::constructor;
 
 void BackgroundSubtractorWrap::Init(Local<Object> target) {
@@ -23,6 +34,9 @@ void BackgroundSubtractorWrap::Init(Local<Object> target) {
   Nan::SetMethod(ctor, "createMOG", CreateMOG);
   Nan::SetPrototypeMethod(ctor, "applyMOG", ApplyMOG);
   Nan::SetPrototypeMethod(ctor, "history", History);
+  Nan::SetPrototypeMethod(ctor, "nmixtures", Mixtures);
+  Nan::SetPrototypeMethod(ctor, "noiseSigma", NoiseSigma);
+  Nan::SetPrototypeMethod(ctor, "backgroundRatio", BackgroundRatio);
 
   target->Set(Nan::New("BackgroundSubtractor").ToLocalChecked(), ctor->GetFunction());
 }
@@ -138,21 +152,50 @@ NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
 
 NAN_METHOD(BackgroundSubtractorWrap::History) {
   SETUP_FUNCTION(BackgroundSubtractorWrap);
-
-#if CV_MAJOR_VERSION >= 3
-  auto mog = dynamic_cast<cv::bgsegm::BackgroundSubtractorMOG *>(self->subtractor.get());
-#else
-  auto mog = dynamic_cast<cv::BackgroundSubtractorMOG *>(self->subtractor.get());
-#endif
+  auto mog = getMOG(self);
   if (!mog) {
     Nan::ThrowError("Not using a BackgroundSubtractorMOG");
   }
-
   if (info.Length() > 0) {
     mog->setHistory(info[0]->NumberValue());
   }
-
   info.GetReturnValue().Set(mog->getHistory());
+}
+
+NAN_METHOD(BackgroundSubtractorWrap::BackgroundRatio) {
+  SETUP_FUNCTION(BackgroundSubtractorWrap);
+  auto mog = getMOG(self);
+  if (!mog) {
+    Nan::ThrowError("Not using a BackgroundSubtractorMOG");
+  }
+  if (info.Length() > 0) {
+    mog->setBackgroundRatio(info[0]->NumberValue());
+  }
+  info.GetReturnValue().Set(mog->getBackgroundRatio());
+}
+
+NAN_METHOD(BackgroundSubtractorWrap::NoiseSigma) {
+  SETUP_FUNCTION(BackgroundSubtractorWrap);
+  auto mog = getMOG(self);
+  if (!mog) {
+    Nan::ThrowError("Not using a BackgroundSubtractorMOG");
+  }
+  if (info.Length() > 0) {
+    mog->setNoiseSigma(info[0]->NumberValue());
+  }
+  info.GetReturnValue().Set(mog->getNoiseSigma());
+}
+
+NAN_METHOD(BackgroundSubtractorWrap::Mixtures) {
+  SETUP_FUNCTION(BackgroundSubtractorWrap);
+  auto mog = getMOG(self);
+  if (!mog) {
+    Nan::ThrowError("Not using a BackgroundSubtractorMOG");
+  }
+  if (info.Length() > 0) {
+    mog->setNMixtures(info[0]->NumberValue());
+  }
+  info.GetReturnValue().Set(mog->getNMixtures());
 }
 
 BackgroundSubtractorWrap::BackgroundSubtractorWrap(

--- a/src/BackgroundSubtractor.h
+++ b/src/BackgroundSubtractor.h
@@ -1,6 +1,7 @@
 #include "OpenCV.h"
 
-#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4))
+#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4)) || (CV_MAJOR_VERSION >= 3)
+#define HAVE_BACKGROUNDSUBTRACTOR
 
 #include <opencv2/video/background_segm.hpp>
 

--- a/src/BackgroundSubtractor.h
+++ b/src/BackgroundSubtractor.h
@@ -19,9 +19,9 @@ public:
   static NAN_METHOD(ApplyMOG);
   
   static NAN_METHOD(History);
-  //static NAN_METHOD(Mixtures);
-  //static NAN_METHOD(NoiseSigma);
-  //static NAN_METHOD(BackgroundRatio);
+  static NAN_METHOD(Mixtures);
+  static NAN_METHOD(NoiseSigma);
+  static NAN_METHOD(BackgroundRatio);
 };
 
 #endif

--- a/src/BackgroundSubtractor.h
+++ b/src/BackgroundSubtractor.h
@@ -17,6 +17,11 @@ public:
 
   static NAN_METHOD(CreateMOG);
   static NAN_METHOD(ApplyMOG);
+  
+  static NAN_METHOD(History);
+  //static NAN_METHOD(Mixtures);
+  //static NAN_METHOD(NoiseSigma);
+  //static NAN_METHOD(BackgroundRatio);
 };
 
 #endif

--- a/src/init.cc
+++ b/src/init.cc
@@ -24,6 +24,9 @@ extern "C" void init(Local<Object> target) {
   Matrix::Init(target);
   CascadeClassifierWrap::Init(target);
   VideoCaptureWrap::Init(target);
+#ifdef HAVE_BACKGROUNDSUBTRACTOR
+  BackgroundSubtractorWrap::Init(target);
+#endif
   Contour::Init(target);
   TrackedObject::Init(target);
   NamedWindow::Init(target);
@@ -35,7 +38,6 @@ extern "C" void init(Local<Object> target) {
   StereoSGBM::Init(target);
   StereoGC::Init(target);
 #if CV_MAJOR_VERSION == 2 && CV_MINOR_VERSION >=4
-  BackgroundSubtractorWrap::Init(target);
   Features::Init(target);
   LDAWrap::Init(target);
 #endif


### PR DESCRIPTION
This fixes #305 for me on OpenCV 3.

I left the codepaths for OpenCV 2 untouched, though I suspect it has issues as well.