### PR TITLE
Add the type function in Matrix class

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -35,6 +35,7 @@ void Matrix::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "pixel", Pixel);
   Nan::SetPrototypeMethod(ctor, "width", Width);
   Nan::SetPrototypeMethod(ctor, "height", Height);
+  Nan::SetPrototypeMethod(ctor, "type", Type);
   Nan::SetPrototypeMethod(ctor, "size", Size);
   Nan::SetPrototypeMethod(ctor, "clone", Clone);
   Nan::SetPrototypeMethod(ctor, "crop", Crop);
@@ -495,6 +496,12 @@ NAN_METHOD(Matrix::Size) {
   arr->Set(1, Nan::New<Number>(self->mat.size().width));
 
   info.GetReturnValue().Set(arr);
+}
+
+NAN_METHOD(Matrix::Type) {
+  SETUP_FUNCTION(Matrix)
+
+  info.GetReturnValue().Set(Nan::New<Int32>(self->mat.type()));
 }
 
 NAN_METHOD(Matrix::Clone) {

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -36,6 +36,7 @@ public:
   JSFUNC(Size)
   JSFUNC(Width)
   JSFUNC(Height)
+  JSFUNC(Type)
   JSFUNC(Channels)
   JSFUNC(Clone)
   JSFUNC(Ellipse)


### PR DESCRIPTION
Hi, When I want to create a Matrix which is the same type as another image, I cannot get the type of the image from the Matrix interface. I think the Matrix may need a type function.