### PR TITLE
include `opencv2/video/tracking.hpp`

### DIFF
--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -23,6 +23,7 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/videoio.hpp>
 #include <opencv2/opencv_modules.hpp>
+#include <opencv2/video/tracking.hpp>
 #endif
 #if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4) && (CV_SUBMINOR_VERSION>=4))
 #define HAVE_OPENCV_FACE


### PR DESCRIPTION
I was getting this error when trying to build on Alpine Linux:

    ‘calcOpticalFlowPyrLK’ is not a member of ‘cv’

Including `tracking.hpp` fixes compilation for me.

Related: https://stackoverflow.com/a/11641833/376773