### PR TITLE
Support for OpenCV 3.3 and fix of #554

### DIFF
--- a/src/HighGUI.cc
+++ b/src/HighGUI.cc
@@ -17,6 +17,7 @@ void NamedWindow::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "show", Show);
   Nan::SetPrototypeMethod(ctor, "destroy", Destroy);
   Nan::SetPrototypeMethod(ctor, "blockingWaitKey", BlockingWaitKey);
+  Nan::SetPrototypeMethod(ctor, "resizeWindow", ResizeWindow);
 
   target->Set(Nan::New("NamedWindow").ToLocalChecked(), ctor->GetFunction());
 };
@@ -32,7 +33,8 @@ NAN_METHOD(NamedWindow::New) {
   if (info.Length() == 1) {
     win = new NamedWindow(std::string(*Nan::Utf8String(info[0]->ToString())), 0);
   } else {  //if (info.Length() == 2){
-    win = new NamedWindow(std::string(*Nan::Utf8String(info[0]->ToString())), 0);
+    win = new NamedWindow(std::string(*Nan::Utf8String(info[0]->ToString())), 
+            info[1]->IntegerValue());
   }
 
   win->Wrap(info.Holder());
@@ -66,8 +68,6 @@ NAN_METHOD(NamedWindow::Destroy) {
 }
 
 NAN_METHOD(NamedWindow::BlockingWaitKey) {
-  Nan::HandleScope scope;
-  //SETUP_FUNCTION(NamedWindow)
   int time = 0;
 
   if (info.Length() > 1) {
@@ -81,4 +81,16 @@ NAN_METHOD(NamedWindow::BlockingWaitKey) {
   int res = cv::waitKey(time);
 
   info.GetReturnValue().Set(Nan::New<Number>(res));
+}
+
+NAN_METHOD(NamedWindow::ResizeWindow) {
+  SETUP_FUNCTION(NamedWindow)
+  
+  if (info.Length() != 2) {
+    throw "expected 2 argurments: width, height";
+  }//otherwise
+
+  int width = info[0]->IntegerValue();
+  int height = info[1]->IntegerValue();
+  cv::resizeWindow(self->winname, width, height);
 }

--- a/src/HighGUI.h
+++ b/src/HighGUI.h
@@ -14,6 +14,7 @@ public:
   JSFUNC(Show)
   ;JSFUNC(Destroy)
   ;JSFUNC(BlockingWaitKey)
+  ;JSFUNC(ResizeWindow)
   ;
 
 };

--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -23,6 +23,7 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/videoio.hpp>
 #include <opencv2/opencv_modules.hpp>
+#include <opencv2/video/tracking.hpp>
 #endif
 #if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4) && (CV_SUBMINOR_VERSION>=4))
 #define HAVE_OPENCV_FACE


### PR DESCRIPTION
Hi,

to make node-opencv work for the current Arch-Linux, I had to adapt some calls to changes in OpenCV 3.3. In case you want to support this, please just have a look at the pull request.

In the second commit, the code fixes #554, and adds a missing function ("resizeWindow").

Regards
Simon