### PR TITLE
Adding getters and setters in VideoCaptureWrap

### DIFF
--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -32,8 +32,12 @@ void VideoCaptureWrap::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "setHeight", SetHeight);
   Nan::SetPrototypeMethod(ctor, "getWidth", GetWidth);
   Nan::SetPrototypeMethod(ctor, "getHeight", GetHeight);
+  Nan::SetPrototypeMethod(ctor, "getPosition", GetPosition);
+  Nan::SetPrototypeMethod(ctor, "getPositionMS", GetPositionMS);
   Nan::SetPrototypeMethod(ctor, "setPosition", SetPosition);
-  Nan::SetPrototypeMethod(ctor, "getFrameAt", GetFrameAt);
+  Nan::SetPrototypeMethod(ctor, "setPositionMS", SetPositionMS);
+  Nan::SetPrototypeMethod(ctor, "getFPS", GetFPS);
+  Nan::SetPrototypeMethod(ctor, "getFourCC", GetFourCC);
   Nan::SetPrototypeMethod(ctor, "getFrameCount", GetFrameCount);
   Nan::SetPrototypeMethod(ctor, "release", Release);
   Nan::SetPrototypeMethod(ctor, "ReadSync", ReadSync);
@@ -41,6 +45,42 @@ void VideoCaptureWrap::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "retrieve", Retrieve);
 
   target->Set(Nan::New("VideoCapture").ToLocalChecked(), ctor->GetFunction());
+}
+
+NAN_METHOD(VideoCaptureWrap::GetPosition) {
+  Nan::HandleScope scope;
+  VideoCaptureWrap *v = Nan::ObjectWrap::Unwrap<VideoCaptureWrap>(info.This());
+
+  int cnt = int(v->cap.get(CV_CAP_PROP_POS_FRAMES));
+
+  info.GetReturnValue().Set(Nan::New<Number>(cnt));
+}
+
+NAN_METHOD(VideoCaptureWrap::GetPositionMS) {
+  Nan::HandleScope scope;
+  VideoCaptureWrap *v = Nan::ObjectWrap::Unwrap<VideoCaptureWrap>(info.This());
+
+  int cnt = int(v->cap.get(CV_CAP_PROP_POS_MSEC));
+
+  info.GetReturnValue().Set(Nan::New<Number>(cnt));
+}
+
+NAN_METHOD(VideoCaptureWrap::GetFPS) {
+  Nan::HandleScope scope;
+  VideoCaptureWrap *v = Nan::ObjectWrap::Unwrap<VideoCaptureWrap>(info.This());
+
+  int cnt = int(v->cap.get(CV_CAP_PROP_FPS));
+
+  info.GetReturnValue().Set(Nan::New<Number>(cnt));
+}
+
+NAN_METHOD(VideoCaptureWrap::GetFourCC) {
+  Nan::HandleScope scope;
+  VideoCaptureWrap *v = Nan::ObjectWrap::Unwrap<VideoCaptureWrap>(info.This());
+
+  int cnt = int(v->cap.get(CV_CAP_PROP_FOURCC));
+
+  info.GetReturnValue().Set(Nan::New<Number>(cnt));
 }
 
 NAN_METHOD(VideoCaptureWrap::New) {
@@ -151,7 +191,7 @@ NAN_METHOD(VideoCaptureWrap::SetPosition) {
   return;
 }
 
-NAN_METHOD(VideoCaptureWrap::GetFrameAt) {
+NAN_METHOD(VideoCaptureWrap::SetPositionMS) {
   Nan::HandleScope scope;
   VideoCaptureWrap *v = Nan::ObjectWrap::Unwrap<VideoCaptureWrap>(info.This());
 

--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -35,6 +35,7 @@ void VideoCaptureWrap::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "getPosition", GetPosition);
   Nan::SetPrototypeMethod(ctor, "getPositionMS", GetPositionMS);
   Nan::SetPrototypeMethod(ctor, "setPosition", SetPosition);
+  Nan::SetPrototypeMethod(ctor, "getFrameAt", GetFrameAt);
   Nan::SetPrototypeMethod(ctor, "setPositionMS", SetPositionMS);
   Nan::SetPrototypeMethod(ctor, "getFPS", GetFPS);
   Nan::SetPrototypeMethod(ctor, "getFourCC", GetFourCC);
@@ -187,6 +188,20 @@ NAN_METHOD(VideoCaptureWrap::SetPosition) {
   int pos = info[0]->IntegerValue();
 
   v->cap.set(CV_CAP_PROP_POS_FRAMES, pos);
+
+  return;
+}
+
+NAN_METHOD(VideoCaptureWrap::GetFrameAt) {
+  Nan::HandleScope scope;
+  VideoCaptureWrap *v = Nan::ObjectWrap::Unwrap<VideoCaptureWrap>(info.This());
+
+  if(info.Length() != 1)
+  return;
+
+  int pos = info[0]->IntegerValue();
+
+  v->cap.set(CV_CAP_PROP_POS_MSEC, pos);
 
   return;
 }

--- a/src/VideoCaptureWrap.h
+++ b/src/VideoCaptureWrap.h
@@ -30,6 +30,7 @@ public:
 
   // to set frame position in milliseconds
   static NAN_METHOD(SetPositionMS);
+  static NAN_METHOD(GetFrameAt); // would deprecate as naming is confusing
 
   // to get 0-based index of the frame to be decoded/captured next
   static NAN_METHOD(GetPosition);

--- a/src/VideoCaptureWrap.h
+++ b/src/VideoCaptureWrap.h
@@ -31,7 +31,7 @@ public:
   // to set frame position in milliseconds
   static NAN_METHOD(SetPositionMS);
 
-  // to get frame position
+  // to get 0-based index of the frame to be decoded/captured next
   static NAN_METHOD(GetPosition);
 
   // to get frame position in milliseconds

--- a/src/VideoCaptureWrap.h
+++ b/src/VideoCaptureWrap.h
@@ -27,9 +27,23 @@ public:
 
   // to set frame position
   static NAN_METHOD(SetPosition);
-  static NAN_METHOD(GetFrameCount);
 
-  static NAN_METHOD(GetFrameAt);
+  // to set frame position in milliseconds
+  static NAN_METHOD(SetPositionMS);
+
+  // to get frame position
+  static NAN_METHOD(GetPosition);
+
+  // to get frame position in milliseconds
+  static NAN_METHOD(GetPositionMS);
+
+  // to get frame rate
+  static NAN_METHOD(GetFPS);
+
+  // to get 4-character code of codec
+  static NAN_METHOD(GetFourCC);
+
+  static NAN_METHOD(GetFrameCount);
 
   // release the stream
   static NAN_METHOD(Release);


### PR DESCRIPTION
Hi,

I have added getPosition, getPositionMS, getFPS, getFourCC and setPositionMS.
setPositionMS is a duplicate of getFrameAt, but as it sets the position in MS I find getFrameAt confusing and would deprecated that in the future. 

What do you think?