### PR TITLE
Add Async to Matix.resize

### DIFF
--- a/examples/async-resize.js
+++ b/examples/async-resize.js
@@ -1,0 +1,34 @@
+var cv = require('../lib/opencv');
+
+cv.readImage("./files/mona.png", function(err, im) {
+  if (err) throw err;
+
+  var width = im.width();
+  var height = im.height();
+  if (width < 1 || height < 1) throw new Error('Image has no size');
+  
+  console.log('Image loaded from ./files/mona.png at '+im.width()+'x'+im.height());
+  
+  var AfterResize = function(err, img){
+    if (err){
+      console.log('Error in resize:' + err);
+      return;
+    }
+    img.save("./tmp/resize-async-image.png");
+    console.log('Image saved to ./tmp/resize-async-image.png at '+img.width()+'x'+img.height());
+  };
+
+  var newwidth = width*0.95;
+  var newheight = height*0.95;
+  
+  var Async = true;
+  if (Async){
+    // note - generates a new image
+    im.resize(newwidth, newheight, AfterResize);
+  } else {
+    // sync - note - modifies the input image
+    im.resize(newwidth, newheight);
+    AfterResize(null, im);
+  }
+  
+});


### PR DESCRIPTION
…run async. Also add fx,fy arguments.

call styles may be:
Sync (modify existing image, new image is CV_32FC3) - same interface as before except added fx,fy
im.resize( width, height );
im.resize( width, height, fx, fy );
im.resize( width, height, interpolation );
im.resize( width, height, fx, fy, interpolation );
Async (create new image, new image is not forced to CV_32FC3?)
where fn = function( err, img ){ }
im.resize( width, height, fn );
im.resize( width, height, fx, fy, fn );
im.resize( width, height, interpolation, fn );
im.resize( width, height, fx, fy, interpolation, fn );

Note: not sure why CV_32FC3 was specified in the original code; left it there for Sync operation, but removed it from Async operation.  Maybe someone with OpenCV knowledge will comment?