### PR TITLE
Btsimonh fix read image

### DIFF
--- a/examples/readimage.js
+++ b/examples/readimage.js
@@ -1,6 +1,12 @@
 var cv = require('../lib/opencv');
 
 
+// read as a buffer for decode operations later
+var fs = require('fs');
+var imgdata = fs.readFileSync("./files/mona.png");
+
+
+
 
 var img = cv.readImage("./files/mona.png");
 console.log('Synchronous readImage("./files/mona.png")'+img.width()+'x'+img.height());
@@ -10,14 +16,11 @@ cv.readImage("./files/mona.png", function(err, im){
 });
 
 img = cv.readImage( 100, 100 );
-console.log('Synchronous readImage(100, 100) (create mat)'+img.width()+'x'+img.height());
+console.log('Synchronous readImage(100, 100) (create mat)'+img.width()+'x'+img.height()+' type '+img.type());
 
 cv.readImage(100, 100, function(err, im){
 	console.log('callback readImage(100, 100, fn(){}) (create mat)'+im.width()+'x'+im.height());
 });
-
-var fs = require('fs');
-var imgdata = fs.readFileSync("./files/mona.png");
 
 img = cv.readImage(imgdata);
 console.log('Synchronous readImage(imgdata:Buffer)'+img.width()+'x'+img.height());
@@ -25,3 +28,31 @@ console.log('Synchronous readImage(imgdata:Buffer)'+img.width()+'x'+img.height()
 cv.readImage(imgdata, function(err, im){
 	console.log('callback readImage(imgdata:Buffer, fn(){})'+im.width()+'x'+im.height());
 });
+
+
+// try with flags now
+console.log('Now with flags');
+
+img = cv.readImage("./files/mona.png", 0);
+console.log('Synchronous readImage("./files/mona.png", 0) (monochrome)'+img.width()+'x'+img.height()+' type '+img.type());
+
+cv.readImage("./files/mona.png", 1, function(err, im){
+	console.log('callback readImage("./files/mona.png", 1, fn(){}) (colour)'+im.width()+'x'+im.height()+' type '+im.type());
+});
+
+img = cv.readImage( 100, 100, cv.Constants.CV_8UC3 );
+console.log('Synchronous readImage(100, 100, cv.Constants.CV_8UC3) (create 8 bit 3 channel mat)'+img.width()+'x'+img.height()+' type '+img.type());
+
+cv.readImage(100, 100, cv.Constants.CV_8UC1, function(err, im){
+	console.log('callback readImage(100, 100, cv.Constants.CV_8UC1, fn(){}) (create mat)'+im.width()+'x'+im.height()+' type '+im.type());
+});
+
+img = cv.readImage(imgdata, 0);
+console.log('Synchronous readImage(imgdata:Buffer, 0) (monochrome)'+img.width()+'x'+img.height()+' type '+img.type());
+
+cv.readImage(imgdata, 1, function(err, im){
+	console.log('callback readImage(imgdata:Buffer, 1, fn(){}) (colour)'+im.width()+'x'+im.height()+' type '+im.type());
+});
+
+
+

--- a/examples/readimage.js
+++ b/examples/readimage.js
@@ -1,0 +1,27 @@
+var cv = require('../lib/opencv');
+
+
+
+var img = cv.readImage("./files/mona.png");
+console.log('Synchronous readImage("./files/mona.png")'+img.width()+'x'+img.height());
+
+cv.readImage("./files/mona.png", function(err, im){
+	console.log('callback readImage("./files/mona.png", fn(){})'+im.width()+'x'+im.height());
+});
+
+img = cv.readImage( 100, 100 );
+console.log('Synchronous readImage(100, 100) (create mat)'+img.width()+'x'+img.height());
+
+cv.readImage(100, 100, function(err, im){
+	console.log('callback readImage(100, 100, fn(){}) (create mat)'+im.width()+'x'+im.height());
+});
+
+var fs = require('fs');
+var imgdata = fs.readFileSync("./files/mona.png");
+
+img = cv.readImage(imgdata);
+console.log('Synchronous readImage(imgdata:Buffer)'+img.width()+'x'+img.height());
+
+cv.readImage(imgdata, function(err, im){
+	console.log('callback readImage(imgdata:Buffer, fn(){})'+im.width()+'x'+im.height());
+});

--- a/src/OpenCV.cc
+++ b/src/OpenCV.cc
@@ -42,25 +42,41 @@ NAN_METHOD(OpenCV::ReadImage) {
 
     if (info[0]->IsNumber() && info[1]->IsNumber()) {
       int width, height;
+      int type = CV_64FC1;
+      // if we have a type arg
+      if ((numargs > 2) && info[2]->IsNumber()){
+        type = info[2]->Uint32Value(); 
+      }
       width = info[0]->Uint32Value();
       height = info[1]->Uint32Value();
-      mat = *(new cv::Mat(width, height, CV_64FC1));
+      mat = *(new cv::Mat(width, height, type));
 
     } else if (info[0]->IsString()) {
       std::string filename = std::string(*Nan::Utf8String(info[0]->ToString()));
-      mat = cv::imread(filename, CV_LOAD_IMAGE_UNCHANGED);
+      int flags = CV_LOAD_IMAGE_UNCHANGED;
+      if (numargs > 1){
+        if (info[1]->IsNumber()){
+          flags = info[1]->Uint32Value();
+        }
+      }
+      mat = cv::imread(filename, flags);
 
     } else if (Buffer::HasInstance(info[0])) {
       uint8_t *buf = (uint8_t *) Buffer::Data(info[0]->ToObject());
       unsigned len = Buffer::Length(info[0]->ToObject());
-
+      int flags = CV_LOAD_IMAGE_UNCHANGED;
+      if (numargs > 1){
+        if (info[1]->IsNumber()){
+          flags = info[1]->Uint32Value();
+        }
+      }
       cv::Mat *mbuf = new cv::Mat(len, 1, CV_64FC1, buf);
-      mat = cv::imdecode(*mbuf, CV_LOAD_IMAGE_UNCHANGED);
-
+      mat = cv::imdecode(*mbuf, flags);
       if (mat.empty()) {
         success = 0;
         argv[0] = Nan::Error("Error loading file");
       }
+      
     }
 
     img->mat = mat;


### PR DESCRIPTION
fixes a small bug in cv.readImage where cv.readimage( width, height, fn(err, im){} ); would not  have worked because the first thing it did was insist on the callback being the second argument.
Also adds ability to supply flags for image reading/creation, and to call without a callback function; where ti then returns the matrix directly.
flags for readImage(filename{, flags} {, fn(){} }) are those for cv::imread
flags for readImage(Buffer{, flags} {, fn(){} }) are those for cv::imdecode
type for readImage(width, height{, type} {, fn(){} }) are those for new cv::Mat(width, height, type)

examples/readimage.js is provided exercising most options.