### PR TITLE
Btsimonh BackgroundSubtractor Async

### DIFF
--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -84,6 +84,63 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateMOG) {
   info.GetReturnValue().Set( n );
 }
 
+NAN_METHOD(BackgroundSubtractorWrap::CreateMOG2) {
+  Nan::HandleScope scope;
+
+  // int history = 200;
+  // int nmixtures = 5;
+  // double backgroundRatio = 0.7;
+  // double noiseSigma = 0;
+  //
+  // if(info.Length() > 1){
+  //   INT_FROM_ARGS(history, 0)
+  //   INT_FROM_ARGS(nmixtures, 1)
+  //   DOUBLE_FROM_ARGS(backgroundRatio, 2)
+  //   DOUBLE_FROM_ARGS(noiseSigma, 3)
+  // }
+
+  Local<Object> n = Nan::NewInstance(Nan::GetFunction(Nan::New(BackgroundSubtractorWrap::constructor)).ToLocalChecked()).ToLocalChecked();
+
+#if CV_MAJOR_VERSION >= 3
+  cv::Ptr<cv::BackgroundSubtractor> bg = cv::createBackgroundSubtractorMOG2();
+#else
+  cv::Ptr<cv::BackgroundSubtractor> bg;
+#endif
+  BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
+
+  pt->Wrap(n);
+  info.GetReturnValue().Set( n );
+}
+
+NAN_METHOD(BackgroundSubtractorWrap::CreateGMG) {
+  Nan::HandleScope scope;
+
+  // int history = 200;
+  // int nmixtures = 5;
+  // double backgroundRatio = 0.7;
+  // double noiseSigma = 0;
+  //
+  // if(info.Length() > 1){
+  //   INT_FROM_ARGS(history, 0)
+  //   INT_FROM_ARGS(nmixtures, 1)
+  //   DOUBLE_FROM_ARGS(backgroundRatio, 2)
+  //   DOUBLE_FROM_ARGS(noiseSigma, 3)
+  // }
+
+  Local<Object> n = Nan::NewInstance(Nan::GetFunction(Nan::New(BackgroundSubtractorWrap::constructor)).ToLocalChecked()).ToLocalChecked();
+
+#if CV_MAJOR_VERSION >= 3
+  cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorGMG();
+#else
+  cv::Ptr<cv::BackgroundSubtractor> bg;
+#endif
+  BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
+
+  pt->Wrap(n);
+  info.GetReturnValue().Set( n );
+}
+
+
 // Fetch foreground mask
 NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
   SETUP_FUNCTION(BackgroundSubtractorWrap);

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -6,9 +6,18 @@
 #ifdef HAVE_BACKGROUNDSUBTRACTOR
 
 #if CV_MAJOR_VERSION >= 3
+
+#ifdef HAVE_OPENCV_BGSEGM
 cv::bgsegm::BackgroundSubtractorMOG* getMOG(BackgroundSubtractorWrap *wrap) {
   return dynamic_cast<cv::bgsegm::BackgroundSubtractorMOG *>(wrap->subtractor.get());
 }
+#else
+// without bgsem, it can;t be MOG anyway
+void* getMOG(BackgroundSubtractorWrap *wrap) {
+  return NULL;
+}
+#endif
+
 #else
 cv::BackgroundSubtractorMOG* getMOG(BackgroundSubtractorWrap *wrap) {
   return dynamic_cast<cv::BackgroundSubtractorMOG *>(wrap->subtractor.get());
@@ -45,7 +54,13 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
 
   // Create MOG by default
 #if CV_MAJOR_VERSION >= 3
+
+#ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
+#else
+  JSTHROW_TYPE("OpenCV built without bgsem (opencv_contrib)")
+#endif
+  
 #else
   cv::Ptr<cv::BackgroundSubtractor> bg;
 #endif
@@ -74,7 +89,11 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateMOG) {
   Local<Object> n = Nan::NewInstance(Nan::GetFunction(Nan::New(BackgroundSubtractorWrap::constructor)).ToLocalChecked()).ToLocalChecked();
 
 #if CV_MAJOR_VERSION >= 3
+#ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
+#else
+  JSTHROW_TYPE("OpenCV built without bgsem (opencv_contrib)")
+#endif
 #else
   cv::Ptr<cv::BackgroundSubtractor> bg;
 #endif
@@ -130,7 +149,11 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateGMG) {
   Local<Object> n = Nan::NewInstance(Nan::GetFunction(Nan::New(BackgroundSubtractorWrap::constructor)).ToLocalChecked()).ToLocalChecked();
 
 #if CV_MAJOR_VERSION >= 3
+#ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorGMG();
+#else
+  JSTHROW_TYPE("OpenCV built without bgsem (opencv_contrib) - use MOG2")
+#endif
 #else
   cv::Ptr<cv::BackgroundSubtractor> bg;
 #endif
@@ -208,10 +231,14 @@ NAN_METHOD(BackgroundSubtractorWrap::History) {
   if (!mog) {
     Nan::ThrowError("Not using a BackgroundSubtractorMOG");
   }
+#ifdef HAVE_OPENCV_BGSEGM
   if (info.Length() > 0) {
     mog->setHistory(info[0]->NumberValue());
   }
   info.GetReturnValue().Set(mog->getHistory());
+#else
+  info.GetReturnValue().Set(Nan::Null());
+#endif    
 }
 
 NAN_METHOD(BackgroundSubtractorWrap::BackgroundRatio) {
@@ -220,10 +247,14 @@ NAN_METHOD(BackgroundSubtractorWrap::BackgroundRatio) {
   if (!mog) {
     Nan::ThrowError("Not using a BackgroundSubtractorMOG");
   }
+#ifdef HAVE_OPENCV_BGSEGM
   if (info.Length() > 0) {
     mog->setBackgroundRatio(info[0]->NumberValue());
   }
   info.GetReturnValue().Set(mog->getBackgroundRatio());
+#else
+  info.GetReturnValue().Set(Nan::Null());
+#endif    
 }
 
 NAN_METHOD(BackgroundSubtractorWrap::NoiseSigma) {
@@ -232,10 +263,14 @@ NAN_METHOD(BackgroundSubtractorWrap::NoiseSigma) {
   if (!mog) {
     Nan::ThrowError("Not using a BackgroundSubtractorMOG");
   }
+#ifdef HAVE_OPENCV_BGSEGM
   if (info.Length() > 0) {
     mog->setNoiseSigma(info[0]->NumberValue());
   }
   info.GetReturnValue().Set(mog->getNoiseSigma());
+#else
+  info.GetReturnValue().Set(Nan::Null());
+#endif    
 }
 
 NAN_METHOD(BackgroundSubtractorWrap::Mixtures) {
@@ -244,10 +279,14 @@ NAN_METHOD(BackgroundSubtractorWrap::Mixtures) {
   if (!mog) {
     Nan::ThrowError("Not using a BackgroundSubtractorMOG");
   }
+#ifdef HAVE_OPENCV_BGSEGM
   if (info.Length() > 0) {
     mog->setNMixtures(info[0]->NumberValue());
   }
   info.GetReturnValue().Set(mog->getNMixtures());
+#else
+  info.GetReturnValue().Set(Nan::Null());
+#endif    
 }
 
 BackgroundSubtractorWrap::BackgroundSubtractorWrap(

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -70,6 +70,7 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
   if (NULL == bg){
    JSTHROW_TYPE("OpenCV NULL from cv::createBackgroundSubtractorMOG2()");
   }
+  BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(info.This());
 

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -6,10 +6,12 @@
 #ifdef HAVE_BACKGROUNDSUBTRACTOR
 
 #ifdef HAVE_OPENCV_BGSEGM
+#warning Building with HAVE_OPENCV_BGSEGM
 cv::bgsegm::BackgroundSubtractorMOG* getMOG(BackgroundSubtractorWrap *wrap) {
   return dynamic_cast<cv::bgsegm::BackgroundSubtractorMOG *>(wrap->subtractor.get());
 }
 #else
+#warning Building without HAVE_OPENCV_BGSEGM
 // without bgsem, it can't be MOG anyway
 void* getMOG(BackgroundSubtractorWrap *wrap) {
   return NULL;
@@ -50,6 +52,7 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
 
   // Create MOG by default
 #if CV_MAJOR_VERSION >= 3
+#warning Building OPENCV >= 3
 
 #ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
@@ -66,6 +69,7 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
 #endif
   
 #else
+#warning Building OPENCV < 3
   cv::Ptr<cv::BackgroundSubtractor> bg = new cv::BackgroundSubtractorMOG();
   if (NULL == bg){
    JSTHROW_TYPE("OpenCV NULL from new cv::BackgroundSubtractorMOG()");

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -3,13 +3,17 @@
 #include <iostream>
 #include <nan.h>
 
-#ifdef HAVE_OPENCV_VIDEO
+#ifdef HAVE_BACKGROUNDSUBTRACTOR
 
 #if CV_MAJOR_VERSION >= 3
-#warning TODO: port me to OpenCV 3
+cv::bgsegm::BackgroundSubtractorMOG* getMOG(BackgroundSubtractorWrap *wrap) {
+  return dynamic_cast<cv::bgsegm::BackgroundSubtractorMOG *>(wrap->subtractor.get());
+}
+#else
+cv::BackgroundSubtractorMOG* getMOG(BackgroundSubtractorWrap *wrap) {
+  return dynamic_cast<cv::BackgroundSubtractorMOG *>(wrap->subtractor.get());
+}
 #endif
-
-#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4))
 
 Nan::Persistent<FunctionTemplate> BackgroundSubtractorWrap::constructor;
 
@@ -24,6 +28,10 @@ void BackgroundSubtractorWrap::Init(Local<Object> target) {
 
   Nan::SetMethod(ctor, "createMOG", CreateMOG);
   Nan::SetPrototypeMethod(ctor, "applyMOG", ApplyMOG);
+  Nan::SetPrototypeMethod(ctor, "history", History);
+  Nan::SetPrototypeMethod(ctor, "nmixtures", Mixtures);
+  Nan::SetPrototypeMethod(ctor, "noiseSigma", NoiseSigma);
+  Nan::SetPrototypeMethod(ctor, "backgroundRatio", BackgroundRatio);
 
   target->Set(Nan::New("BackgroundSubtractor").ToLocalChecked(), ctor->GetFunction());
 }
@@ -36,8 +44,13 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
   }
 
   // Create MOG by default
+#if CV_MAJOR_VERSION >= 3
+  cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
+#else
   cv::Ptr<cv::BackgroundSubtractor> bg;
+#endif
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
+
   pt->Wrap(info.This());
 
   info.GetReturnValue().Set(info.This());
@@ -60,7 +73,11 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateMOG) {
 
   Local<Object> n = Nan::NewInstance(Nan::GetFunction(Nan::New(BackgroundSubtractorWrap::constructor)).ToLocalChecked()).ToLocalChecked();
 
+#if CV_MAJOR_VERSION >= 3
+  cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
+#else
   cv::Ptr<cv::BackgroundSubtractor> bg;
+#endif
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(n);
@@ -102,7 +119,11 @@ NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
     }
 
     cv::Mat _fgMask;
+#if CV_MAJOR_VERSION >= 3
+    self->subtractor->apply(mat, _fgMask);
+#else
     self->subtractor->operator()(mat, _fgMask);
+#endif
 
     img->mat = _fgMask;
     mat.release();
@@ -124,6 +145,54 @@ NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
   }
 }
 
+NAN_METHOD(BackgroundSubtractorWrap::History) {
+  SETUP_FUNCTION(BackgroundSubtractorWrap);
+  auto mog = getMOG(self);
+  if (!mog) {
+    Nan::ThrowError("Not using a BackgroundSubtractorMOG");
+  }
+  if (info.Length() > 0) {
+    mog->setHistory(info[0]->NumberValue());
+  }
+  info.GetReturnValue().Set(mog->getHistory());
+}
+
+NAN_METHOD(BackgroundSubtractorWrap::BackgroundRatio) {
+  SETUP_FUNCTION(BackgroundSubtractorWrap);
+  auto mog = getMOG(self);
+  if (!mog) {
+    Nan::ThrowError("Not using a BackgroundSubtractorMOG");
+  }
+  if (info.Length() > 0) {
+    mog->setBackgroundRatio(info[0]->NumberValue());
+  }
+  info.GetReturnValue().Set(mog->getBackgroundRatio());
+}
+
+NAN_METHOD(BackgroundSubtractorWrap::NoiseSigma) {
+  SETUP_FUNCTION(BackgroundSubtractorWrap);
+  auto mog = getMOG(self);
+  if (!mog) {
+    Nan::ThrowError("Not using a BackgroundSubtractorMOG");
+  }
+  if (info.Length() > 0) {
+    mog->setNoiseSigma(info[0]->NumberValue());
+  }
+  info.GetReturnValue().Set(mog->getNoiseSigma());
+}
+
+NAN_METHOD(BackgroundSubtractorWrap::Mixtures) {
+  SETUP_FUNCTION(BackgroundSubtractorWrap);
+  auto mog = getMOG(self);
+  if (!mog) {
+    Nan::ThrowError("Not using a BackgroundSubtractorMOG");
+  }
+  if (info.Length() > 0) {
+    mog->setNMixtures(info[0]->NumberValue());
+  }
+  info.GetReturnValue().Set(mog->getNMixtures());
+}
+
 BackgroundSubtractorWrap::BackgroundSubtractorWrap(
     cv::Ptr<cv::BackgroundSubtractor> _subtractor) {
   subtractor = _subtractor;
@@ -131,4 +200,3 @@ BackgroundSubtractorWrap::BackgroundSubtractorWrap(
 
 #endif
 
-#endif

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -65,7 +65,15 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
 
   info.GetReturnValue().Set(info.This());
 #else
-  JSTHROW_TYPE("OpenCV built without bgsem (opencv_contrib)")
+  // if no bgsem, then default to MOG2
+  cv::Ptr<cv::BackgroundSubtractor> bg = cv::createBackgroundSubtractorMOG2();
+  if (NULL == bg){
+   JSTHROW_TYPE("OpenCV NULL from cv::createBackgroundSubtractorMOG2()");
+  }
+
+  pt->Wrap(info.This());
+
+  info.GetReturnValue().Set(info.This());
 #endif
   
 #else

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -53,18 +53,23 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
 
 #ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
+  BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
+
+  pt->Wrap(info.This());
+
+  info.GetReturnValue().Set(info.This());
 #else
   JSTHROW_TYPE("OpenCV built without bgsem (opencv_contrib)")
 #endif
   
 #else
   cv::Ptr<cv::BackgroundSubtractor> bg;
-#endif
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(info.This());
 
   info.GetReturnValue().Set(info.This());
+#endif
 }
 
 NAN_METHOD(BackgroundSubtractorWrap::CreateMOG) {
@@ -87,16 +92,20 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateMOG) {
 #if CV_MAJOR_VERSION >= 3
 #ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
+  BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
+
+  pt->Wrap(n);
+  info.GetReturnValue().Set( n );
 #else
   JSTHROW_TYPE("OpenCV built without bgsem (opencv_contrib)")
 #endif
 #else
   cv::Ptr<cv::BackgroundSubtractor> bg;
-#endif
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(n);
   info.GetReturnValue().Set( n );
+#endif
 }
 
 NAN_METHOD(BackgroundSubtractorWrap::CreateMOG2) {
@@ -147,16 +156,20 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateGMG) {
 #if CV_MAJOR_VERSION >= 3
 #ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorGMG();
+  BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
+
+  pt->Wrap(n);
+  info.GetReturnValue().Set( n );
 #else
   JSTHROW_TYPE("OpenCV built without bgsem (opencv_contrib) - use MOG2")
 #endif
 #else
   cv::Ptr<cv::BackgroundSubtractor> bg;
-#endif
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(n);
   info.GetReturnValue().Set( n );
+#endif
 }
 
 

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -5,24 +5,17 @@
 
 #ifdef HAVE_BACKGROUNDSUBTRACTOR
 
-#if CV_MAJOR_VERSION >= 3
-
 #ifdef HAVE_OPENCV_BGSEGM
 cv::bgsegm::BackgroundSubtractorMOG* getMOG(BackgroundSubtractorWrap *wrap) {
   return dynamic_cast<cv::bgsegm::BackgroundSubtractorMOG *>(wrap->subtractor.get());
 }
 #else
-// without bgsem, it can;t be MOG anyway
+// without bgsem, it can't be MOG anyway
 void* getMOG(BackgroundSubtractorWrap *wrap) {
   return NULL;
 }
 #endif
 
-#else
-cv::BackgroundSubtractorMOG* getMOG(BackgroundSubtractorWrap *wrap) {
-  return dynamic_cast<cv::BackgroundSubtractorMOG *>(wrap->subtractor.get());
-}
-#endif
 
 Nan::Persistent<FunctionTemplate> BackgroundSubtractorWrap::constructor;
 
@@ -231,6 +224,7 @@ NAN_METHOD(BackgroundSubtractorWrap::History) {
   if (!mog) {
     Nan::ThrowError("Not using a BackgroundSubtractorMOG");
   }
+// only support  for V3+ with opencv-contrib
 #ifdef HAVE_OPENCV_BGSEGM
   if (info.Length() > 0) {
     mog->setHistory(info[0]->NumberValue());
@@ -247,6 +241,7 @@ NAN_METHOD(BackgroundSubtractorWrap::BackgroundRatio) {
   if (!mog) {
     Nan::ThrowError("Not using a BackgroundSubtractorMOG");
   }
+// only support  for V3+ with opencv-contrib
 #ifdef HAVE_OPENCV_BGSEGM
   if (info.Length() > 0) {
     mog->setBackgroundRatio(info[0]->NumberValue());
@@ -263,6 +258,7 @@ NAN_METHOD(BackgroundSubtractorWrap::NoiseSigma) {
   if (!mog) {
     Nan::ThrowError("Not using a BackgroundSubtractorMOG");
   }
+// only support  for V3+ with opencv-contrib
 #ifdef HAVE_OPENCV_BGSEGM
   if (info.Length() > 0) {
     mog->setNoiseSigma(info[0]->NumberValue());
@@ -279,6 +275,7 @@ NAN_METHOD(BackgroundSubtractorWrap::Mixtures) {
   if (!mog) {
     Nan::ThrowError("Not using a BackgroundSubtractorMOG");
   }
+// only support  for V3+ with opencv-contrib
 #ifdef HAVE_OPENCV_BGSEGM
   if (info.Length() > 0) {
     mog->setNMixtures(info[0]->NumberValue());

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -6,12 +6,23 @@
 #ifdef HAVE_BACKGROUNDSUBTRACTOR
 
 #ifdef HAVE_OPENCV_BGSEGM
+
+#ifdef __GNUC__
 #warning Building with HAVE_OPENCV_BGSEGM
+#else
+// vs style message pragma
+#pragma message ( "Building with HAVE_OPENCV_BGSEGM" )
+#endif
 cv::bgsegm::BackgroundSubtractorMOG* getMOG(BackgroundSubtractorWrap *wrap) {
   return dynamic_cast<cv::bgsegm::BackgroundSubtractorMOG *>(wrap->subtractor.get());
 }
 #else
+#ifdef __GNUC__
 #warning Building without HAVE_OPENCV_BGSEGM
+#else
+// vs style message pragma
+#pragma message ( "Building without HAVE_OPENCV_BGSEGM" )
+#endif
 // without bgsem, it can't be MOG anyway
 void* getMOG(BackgroundSubtractorWrap *wrap) {
   return NULL;
@@ -52,7 +63,12 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
 
   // Create MOG by default
 #if CV_MAJOR_VERSION >= 3
+#ifdef __GNUC__
 #warning Building OPENCV >= 3
+#else
+// vs style message pragma
+#pragma message ( "Building OPENCV >= 3" )
+#endif
 
 #ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
@@ -78,7 +94,12 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
 #endif
   
 #else
+#ifdef __GNUC__
 #warning Building OPENCV < 3
+#else
+// vs style message pragma
+#pragma message ( "Building OPENCV < 3" )
+#endif
   cv::Ptr<cv::BackgroundSubtractor> bg = new cv::BackgroundSubtractorMOG();
   if (NULL == bg){
    JSTHROW_TYPE("OpenCV NULL from new cv::BackgroundSubtractorMOG()");

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -53,6 +53,9 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
 
 #ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
+  if (NULL == bg){
+   JSTHROW_TYPE("OpenCV NULL from cv::bgsegm::createBackgroundSubtractorMOG()");
+  }
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(info.This());
@@ -63,7 +66,10 @@ NAN_METHOD(BackgroundSubtractorWrap::New) {
 #endif
   
 #else
-  cv::Ptr<cv::BackgroundSubtractor> bg;
+  cv::Ptr<cv::BackgroundSubtractor> bg = new cv::BackgroundSubtractorMOG();
+  if (NULL == bg){
+   JSTHROW_TYPE("OpenCV NULL from new cv::BackgroundSubtractorMOG()");
+  }
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(info.This());
@@ -92,6 +98,9 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateMOG) {
 #if CV_MAJOR_VERSION >= 3
 #ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorMOG();
+  if (NULL == bg){
+   JSTHROW_TYPE("OpenCV NULL from cv::bgsegm::createBackgroundSubtractorMOG()");
+  }
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(n);
@@ -100,7 +109,10 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateMOG) {
   JSTHROW_TYPE("OpenCV built without bgsem (opencv_contrib)")
 #endif
 #else
-  cv::Ptr<cv::BackgroundSubtractor> bg;
+  cv::Ptr<cv::BackgroundSubtractor> bg = new cv::BackgroundSubtractorMOG();
+  if (NULL == bg){
+   JSTHROW_TYPE("OpenCV NULL from new cv::BackgroundSubtractorMOG()");
+  }
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(n);
@@ -127,8 +139,14 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateMOG2) {
 
 #if CV_MAJOR_VERSION >= 3
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::createBackgroundSubtractorMOG2();
+  if (NULL == bg){
+   JSTHROW_TYPE("OpenCV NULL from cv::createBackgroundSubtractorMOG2()");
+  }
 #else
-  cv::Ptr<cv::BackgroundSubtractor> bg;
+  cv::Ptr<cv::BackgroundSubtractor> bg = new cv::BackgroundSubtractorMOG();
+  if (NULL == bg){
+   JSTHROW_TYPE("OpenCV NULL from new cv::BackgroundSubtractorMOG()");
+  }
 #endif
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
@@ -156,6 +174,9 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateGMG) {
 #if CV_MAJOR_VERSION >= 3
 #ifdef HAVE_OPENCV_BGSEGM
   cv::Ptr<cv::BackgroundSubtractor> bg = cv::bgsegm::createBackgroundSubtractorGMG();
+  if (NULL == bg){
+   JSTHROW_TYPE("OpenCV NULL from cv::bgsegm::createBackgroundSubtractorGMG()");
+  }
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(n);
@@ -164,7 +185,10 @@ NAN_METHOD(BackgroundSubtractorWrap::CreateGMG) {
   JSTHROW_TYPE("OpenCV built without bgsem (opencv_contrib) - use MOG2")
 #endif
 #else
-  cv::Ptr<cv::BackgroundSubtractor> bg;
+  cv::Ptr<cv::BackgroundSubtractor> bg = new cv::BackgroundSubtractorMOG();
+  if (NULL == bg){
+   JSTHROW_TYPE("OpenCV NULL from new cv::BackgroundSubtractorMOG()");
+  }
   BackgroundSubtractorWrap *pt = new BackgroundSubtractorWrap(bg);
 
   pt->Wrap(n);
@@ -186,6 +210,13 @@ NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
     return;
   }
 
+  if (NULL == self->subtractor){
+    argv[0] = Nan::New("BackgroundSubtractor not created").ToLocalChecked();
+    argv[1] = Nan::Null();
+    cb->Call(Nan::GetCurrentContext()->Global(), 2, argv);
+    return;
+  }
+  
   try {
     Local<Object> fgMask =
         Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
@@ -302,7 +333,13 @@ NAN_METHOD(BackgroundSubtractorWrap::Apply) {
     cb->Call(Nan::GetCurrentContext()->Global(), 2, argv);
     return;
   }
-
+  if (NULL == self->subtractor){
+    argv[0] = Nan::New("BackgroundSubtractor not created").ToLocalChecked();
+    argv[1] = Nan::Null();
+    cb->Call(Nan::GetCurrentContext()->Global(), 2, argv);
+    return;
+  }
+  
   Nan::Callback *callback = new Nan::Callback(cb.As<Function>());
   Matrix *_img = Nan::ObjectWrap::Unwrap<Matrix>(info[0]->ToObject());
   Nan::AsyncQueueWorker(new AsyncBackgroundSubtractorWorker( callback, self, _img));

--- a/src/BackgroundSubtractor.h
+++ b/src/BackgroundSubtractor.h
@@ -19,6 +19,9 @@ public:
   BackgroundSubtractorWrap(cv::Ptr<cv::BackgroundSubtractor> bg);
 
   static NAN_METHOD(CreateMOG);
+  static NAN_METHOD(CreateMOG2);
+  static NAN_METHOD(CreateGMG);
+  
   static NAN_METHOD(ApplyMOG);
   static NAN_METHOD(History);
   static NAN_METHOD(Mixtures);

--- a/src/BackgroundSubtractor.h
+++ b/src/BackgroundSubtractor.h
@@ -14,6 +14,7 @@
 class BackgroundSubtractorWrap: public Nan::ObjectWrap {
 public:
   cv::Ptr<cv::BackgroundSubtractor> subtractor;
+  cv::Mutex applymutex;
 
   static Nan::Persistent<FunctionTemplate> constructor;
   static void Init(Local<Object> target);

--- a/src/BackgroundSubtractor.h
+++ b/src/BackgroundSubtractor.h
@@ -6,7 +6,10 @@
 #define HAVE_BACKGROUNDSUBTRACTOR
 
 #include <opencv2/video/background_segm.hpp>
+
+#ifdef HAVE_OPENCV_BGSEGM
 #include <opencv2/bgsegm.hpp>
+#endif
 
 class BackgroundSubtractorWrap: public Nan::ObjectWrap {
 public:

--- a/src/BackgroundSubtractor.h
+++ b/src/BackgroundSubtractor.h
@@ -2,9 +2,11 @@
 
 #ifdef HAVE_OPENCV_VIDEO
 
-#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4))
+#if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4)) || (CV_MAJOR_VERSION >= 3)
+#define HAVE_BACKGROUNDSUBTRACTOR
 
 #include <opencv2/video/background_segm.hpp>
+#include <opencv2/bgsegm.hpp>
 
 class BackgroundSubtractorWrap: public Nan::ObjectWrap {
 public:
@@ -18,6 +20,11 @@ public:
 
   static NAN_METHOD(CreateMOG);
   static NAN_METHOD(ApplyMOG);
+  static NAN_METHOD(History);
+  static NAN_METHOD(Mixtures);
+  static NAN_METHOD(NoiseSigma);
+  static NAN_METHOD(BackgroundRatio);
+
 };
 
 #endif

--- a/src/BackgroundSubtractor.h
+++ b/src/BackgroundSubtractor.h
@@ -26,6 +26,7 @@ public:
   static NAN_METHOD(CreateGMG);
   
   static NAN_METHOD(ApplyMOG);
+  static NAN_METHOD(Apply);
   static NAN_METHOD(History);
   static NAN_METHOD(Mixtures);
   static NAN_METHOD(NoiseSigma);

--- a/src/init.cc
+++ b/src/init.cc
@@ -50,15 +50,16 @@ extern "C" void init(Local<Object> target) {
   StereoBM::Init(target);
   StereoSGBM::Init(target);
   StereoGC::Init(target);
+
 #if CV_MAJOR_VERSION == 2 && CV_MINOR_VERSION >=4
-  #ifdef HAVE_OPENCV_VIDEO
-    BackgroundSubtractorWrap::Init(target);
-  #endif
   #ifdef HAVE_OPENCV_FEATURES2D
     Features::Init(target);
   #endif
   LDAWrap::Init(target);
 #endif
+#endif
+#ifdef HAVE_BACKGROUNDSUBTRACTOR
+  BackgroundSubtractorWrap::Init(target);
 #endif
 #ifdef HAVE_OPENCV_FACE
   FaceRecognizerWrap::Init(target);


### PR DESCRIPTION
re-implementation of jonnar's original pull request (#473) onto 'available-modules' branch, plus two extra features
Allows use of BackgroundSubtractor with OpenCV3, plus adds access to MOG2 and GMG subtractors.
Added code to correctly compile if OpenCV was not built with opencv-contrib

Adds Async tot he calls.
Add a fix found after someone tried compiling without bgsem (opencv-contrib).
Retired previous pull request (which was without Async)
