### PR TITLE
fix vs compile error due to warning lines

### DIFF
--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -6,7 +6,12 @@
 #ifdef HAVE_OPENCV_VIDEO
 
 #if CV_MAJOR_VERSION >= 3
+#ifdef __GNUC__
 #warning TODO: port me to OpenCV 3
+#else
+// vs style message pragma
+#pragma message ( "TODO: port me to OpenCV 3" )
+#endif
 #endif
 
 #if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4))

--- a/src/LDAWrap.cc
+++ b/src/LDAWrap.cc
@@ -1,7 +1,12 @@
 #include "OpenCV.h"
 
 #if CV_MAJOR_VERSION >= 3
+#ifdef __GNUC__
 #warning TODO: port me to OpenCV 3
+#else
+// vs style message pragma
+#pragma message ( "TODO: port me to OpenCV 3" )
+#endif
 #endif
 
 #if ((CV_MAJOR_VERSION == 2) && (CV_MINOR_VERSION >=4) && (CV_SUBMINOR_VERSION>=4))

--- a/src/Stereo.cc
+++ b/src/Stereo.cc
@@ -2,7 +2,12 @@
 #include "Stereo.h"
 
 #if CV_MAJOR_VERSION >= 3
+#ifdef __GNUC__
 #warning TODO: port me to OpenCV 3
+#else
+// vs style message pragma
+#pragma message ( "TODO: port me to OpenCV 3" )
+#endif
 #endif
 
 #if CV_MAJOR_VERSION < 3


### PR DESCRIPTION
VS did not compile with #warning, so now detect __GNUC__ and if found, use #warning else use #pragma message ( "message" )
