### PR TITLE
Resize (async) exception checking and memory leak prevention

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -1895,14 +1895,14 @@ public:
   ResizeASyncWorker(Nan::Callback *callback, Matrix *image, cv::Size size, double fx, double fy, int interpolation) :
       Nan::AsyncWorker(callback),
       image(image),
+      dest(NULL),
       size(size),
       fx(fx),
       fy(fy),
       interpolation(interpolation),
-      success(0),
-      dest(NULL){
+      success(0) {
   }
-
+    
   ~ResizeASyncWorker() {
       // don't leave this if it was allocated
       // could happen if NaN does not call HandleSuccess?

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -1900,13 +1900,14 @@ public:
       fy(fy),
       interpolation(interpolation),
       success(0),
-      dest(null){
+      dest(NULL){
   }
 
   ~ResizeASyncWorker() {
       // don't leave this if it was allocated
       // could happen if NaN does not call HandleSuccess?
       delete dest;
+      dest = NULL;
   }
 
   void Execute() {
@@ -1928,7 +1929,7 @@ public:
             Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im_to_return);
             img->mat = dest->mat;
             delete dest;
-            dest = null;
+            dest = NULL;
 
             Local<Value> argv[] = {
               Nan::Null(), // err
@@ -1942,7 +1943,7 @@ public:
             }
         } catch (...){
             delete dest;
-            dest = null;
+            dest = NULL;
             Local<Value> argv[] = {
               Nan::New("C++ exception wrapping response").ToLocalChecked(), // err
               Nan::Null() // result
@@ -1956,7 +1957,7 @@ public:
         }
     } else {
         delete dest;
-        dest = null;
+        dest = NULL;
         
         Local<Value> argv[] = {
           Nan::New("C++ exception").ToLocalChecked(), // err

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -1899,10 +1899,14 @@ public:
       fx(fx),
       fy(fy),
       interpolation(interpolation),
-      success(0){
+      success(0),
+      dest(null){
   }
 
   ~ResizeASyncWorker() {
+      // don't leave this if it was allocated
+      // could happen if NaN does not call HandleSuccess?
+      delete dest;
   }
 
   void Execute() {
@@ -1924,8 +1928,7 @@ public:
             Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im_to_return);
             img->mat = dest->mat;
             delete dest;
-
-            //delete dest;
+            dest = null;
 
             Local<Value> argv[] = {
               Nan::Null(), // err
@@ -1938,6 +1941,8 @@ public:
               Nan::FatalException(try_catch);
             }
         } catch (...){
+            delete dest;
+            dest = null;
             Local<Value> argv[] = {
               Nan::New("C++ exception wrapping response").ToLocalChecked(), // err
               Nan::Null() // result
@@ -1951,6 +1956,7 @@ public:
         }
     } else {
         delete dest;
+        dest = null;
         
         Local<Value> argv[] = {
           Nan::New("C++ exception").ToLocalChecked(), // err


### PR DESCRIPTION
Eliminates a possible memory leak if an error occurs.
Add try/catch to report errors via callback rather than blow node.