### PR TITLE
Asyncprotection

### DIFF
--- a/examples/async-resize.js
+++ b/examples/async-resize.js
@@ -16,6 +16,8 @@ cv.readImage("./files/mona.png", function(err, im) {
     }
     img.save("./tmp/resize-async-image.png");
     console.log('Image saved to ./tmp/resize-async-image.png at '+img.width()+'x'+img.height());
+	img.release();
+	delete img;
   };
 
   var newwidth = width*0.95;
@@ -25,6 +27,8 @@ cv.readImage("./files/mona.png", function(err, im) {
   if (Async){
     // note - generates a new image
     im.resize(newwidth, newheight, AfterResize);
+	im.release(); // test release image before resize if done
+	delete im;
   } else {
     // sync - note - modifies the input image
     im.resize(newwidth, newheight);

--- a/examples/write-video.js
+++ b/examples/write-video.js
@@ -27,3 +27,33 @@ vid.read(function(err, mat) {
 });
 
 
+
+// restart video read
+var vid2 = new cv.VideoCapture(path.join(__dirname, 'files', 'motion.mov'));
+
+var filename2 = './tmp/output-async-'+new Date().getTime()+'.avi';
+var writer2 = null;
+var x = 0;
+
+// do the same write async
+var iter = function () {
+  vid2.read(function (err, m2) {
+	if (writer2 === null)
+	  writer2 = new cv.VideoWriter(filename2, 'DIVX', vid2.getFPS(), m2.size(), true);
+
+	x++;
+	writer2.write(m2, function(err){
+	  if (x < 100) {
+		iter();
+	  } else {
+		vid2.release();
+		writer2.release();
+	  }
+	});
+	m2.release();
+	delete m2;
+  });
+};
+
+// kick it off
+iter();

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -1047,9 +1047,9 @@ NAN_METHOD(Matrix::Save) {
 // https://github.com/rvagg/nan/blob/c579ae858ae3208d7e702e8400042ba9d48fa64b/examples/async_pi_estimate/async.cc
 class AsyncSaveWorker: public Nan::AsyncWorker {
 public:
-  AsyncSaveWorker(Nan::Callback *callback, Matrix* matrix, char* filename) :
+  AsyncSaveWorker(Nan::Callback *callback, cv::Mat mat, char* filename) :
       Nan::AsyncWorker(callback),
-      matrix(matrix),
+      mat(mat),
       filename(filename) {
   }
 
@@ -1061,7 +1061,7 @@ public:
   // here, so everything we need for input and output
   // should go on `this`.
   void Execute() {
-    res = cv::imwrite(this->filename, this->matrix->mat);
+    res = cv::imwrite(this->filename, this->mat);
   }
 
   // Executed when the async work is complete
@@ -1083,7 +1083,7 @@ public:
   }
 
 private:
-  Matrix* matrix;
+  cv::Mat mat;
   std::string filename;
   int res;
 };
@@ -1100,7 +1100,7 @@ NAN_METHOD(Matrix::SaveAsync) {
   REQ_FUN_ARG(1, cb);
 
   Nan::Callback *callback = new Nan::Callback(cb.As<Function>());
-  Nan::AsyncQueueWorker(new AsyncSaveWorker(callback, self, *filename));
+  Nan::AsyncQueueWorker(new AsyncSaveWorker(callback, self->mat, *filename));
 
   return;
 }

--- a/src/VideoWriterWrap.cc
+++ b/src/VideoWriterWrap.cc
@@ -90,10 +90,10 @@ NAN_METHOD(VideoWriterWrap::Release) {
 
 class AsyncVWWorker: public Nan::AsyncWorker {
 public:
-    AsyncVWWorker(Nan::Callback *callback, VideoWriterWrap *vw, Matrix *im) :
+    AsyncVWWorker(Nan::Callback *callback, VideoWriterWrap *vw, cv::Mat mat) :
             Nan::AsyncWorker(callback),
             vw(vw),
-            im(im) {
+            mat(mat) {
     }
 
     ~AsyncVWWorker() {
@@ -104,7 +104,7 @@ public:
     // here, so everything we need for input and output
     // should go on `this`.
     void Execute() {
-      this->vw->writer.write(im->mat);
+      this->vw->writer.write(mat);
     }
 
     // Executed when the async work is complete
@@ -126,7 +126,7 @@ public:
 
 private:
     VideoWriterWrap *vw;
-    Matrix* im;
+    cv::Mat mat;
 };
 
 NAN_METHOD(VideoWriterWrap::Write) {
@@ -137,7 +137,7 @@ NAN_METHOD(VideoWriterWrap::Write) {
     REQ_FUN_ARG(1, cb);
 
     Nan::Callback *callback = new Nan::Callback(cb.As<Function>());
-    Nan::AsyncQueueWorker(new AsyncVWWorker(callback, v, im));
+    Nan::AsyncQueueWorker(new AsyncVWWorker(callback, v, im->mat));
 
     return;
 }


### PR DESCRIPTION
This pull request modifies a number of Async callbacks to pass cv::Mat rather than Matrix *.
When the worker is created, it stores a cv::Mat internally, generated from the passed Mat.  What this actually does is copy the data pointer, and increment the data's reference count.
The result of this is that the input Matrix can have matrix.release() called *before* the async function has done it's work, and not crash.
This pull request includes updates to backgroundsubtractor, resize, asyncsave, videwriter, toBuffer, plus a few of the examples have been updated to call mat.release() so that this feature is tested.