### PR TITLE
Refcount

### DIFF
--- a/examples/matrix-ref-count.js
+++ b/examples/matrix-ref-count.js
@@ -4,27 +4,19 @@ cv.readImage('./files/mona.png', function(err, im) {
   if (err) throw err;
   if (im.width() < 1 || im.height() < 1) throw new Error('Image has no size');
 
+
+  // getrefCount will give the refcount.  if > 0, then a reference ptr is present, and the value returned.
+  // if -1, no reference pointer was present (i.e. the mat does not know about any data).
   var refcount = im.getrefCount();
   console.log('initial refcount '+refcount);
+  if (refcount !== 1)
+	  throw "refcountmismatch - initial should be 1";
   
-  im.addref();
-  var refcount2 = im.getrefCount();
-  console.log('refcount after addref '+refcount2);
-  if (refcount2 !== (refcount + 1))
-	  throw "refcountmismatch";
-
-  im.addref();
-  refcount2 = im.getrefCount();
-  console.log('refcount after addref 2 '+refcount2);
-  if (refcount2 !== (refcount + 2))
-	  throw "refcountmismatch";
-	
-	
   im.release();
   var refcount3 = im.getrefCount();
   console.log('refcount after release (seems should be -1) '+refcount3);
   if (refcount3 !== -1)
-	  throw "refcountmismatch";
+	  throw "refcountmismatch - after release should be -1";
 
   // data is now still there somewhere, but lost to us - this is NOT a good situation.
 

--- a/examples/matrix-ref-count.js
+++ b/examples/matrix-ref-count.js
@@ -1,0 +1,35 @@
+var cv = require('../lib/opencv');
+
+cv.readImage('./files/mona.png', function(err, im) {
+  if (err) throw err;
+  if (im.width() < 1 || im.height() < 1) throw new Error('Image has no size');
+
+  var refcount = im.getrefCount();
+  console.log('initial refcount '+refcount);
+  
+  im.addref();
+  var refcount2 = im.getrefCount();
+  console.log('refcount after addref '+refcount2);
+  if (refcount2 !== (refcount + 1))
+	  throw "refcountmismatch";
+
+  im.addref();
+  refcount2 = im.getrefCount();
+  console.log('refcount after addref 2 '+refcount2);
+  if (refcount2 !== (refcount + 2))
+	  throw "refcountmismatch";
+	
+	
+  im.release();
+  var refcount3 = im.getrefCount();
+  console.log('refcount after release (seems should be -1) '+refcount3);
+  if (refcount3 !== -1)
+	  throw "refcountmismatch";
+
+  // data is now still there somewhere, but lost to us - this is NOT a good situation.
+
+  // should not fail - but will do absolutely nothing
+  im.release();
+  
+  console.log('did all refcount tests');
+});

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -117,7 +117,8 @@ void Matrix::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "mean", Mean);
   Nan::SetPrototypeMethod(ctor, "shift", Shift);
   Nan::SetPrototypeMethod(ctor, "reshape", Reshape);
-  Nan::SetPrototypeMethod(ctor, "addref", Addref);
+// leave this out - can't see a way it could be useful to us, as release() always completely forgets the data
+//  Nan::SetPrototypeMethod(ctor, "addref", Addref);
   Nan::SetPrototypeMethod(ctor, "release", Release);
   Nan::SetPrototypeMethod(ctor, "getrefCount", GetrefCount);
   Nan::SetPrototypeMethod(ctor, "subtract", Subtract);
@@ -3027,14 +3028,15 @@ NAN_METHOD(Matrix::Release) {
   return;
 }
 
-NAN_METHOD(Matrix::Addref) {
-  Nan::HandleScope scope;
-
-  Matrix *self = Nan::ObjectWrap::Unwrap<Matrix>(info.This());
-  self->mat.addref();
-
-  return;
-}
+// leave this out - can't see a way it could be useful to us, as release() always completely forgets the data
+//NAN_METHOD(Matrix::Addref) {
+//  Nan::HandleScope scope;
+//
+//  Matrix *self = Nan::ObjectWrap::Unwrap<Matrix>(info.This());
+//  self->mat.addref();
+//
+//  return;
+//}
 
 
 NAN_METHOD(Matrix::GetrefCount) {
@@ -3047,13 +3049,13 @@ NAN_METHOD(Matrix::GetrefCount) {
     if (self->mat.u){
         refcount = self->mat.u->refcount;
     } else {
-        refcount = -1;
+        refcount = -1; // indicates no reference ptr
     }
 #else
     if (self->mat.refcount){
         refcount = *(self->mat.refcount);
     } else {
-        refcount = -1;
+        refcount = -1; // indicates no reference ptr
     }
 #endif    
 

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -117,7 +117,9 @@ void Matrix::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "mean", Mean);
   Nan::SetPrototypeMethod(ctor, "shift", Shift);
   Nan::SetPrototypeMethod(ctor, "reshape", Reshape);
+  Nan::SetPrototypeMethod(ctor, "addref", Addref);
   Nan::SetPrototypeMethod(ctor, "release", Release);
+  Nan::SetPrototypeMethod(ctor, "getrefCount", GetrefCount);
   Nan::SetPrototypeMethod(ctor, "subtract", Subtract);
   Nan::SetPrototypeMethod(ctor, "compare", Compare);
   Nan::SetPrototypeMethod(ctor, "mul", Mul);
@@ -3024,6 +3026,41 @@ NAN_METHOD(Matrix::Release) {
 
   return;
 }
+
+NAN_METHOD(Matrix::Addref) {
+  Nan::HandleScope scope;
+
+  Matrix *self = Nan::ObjectWrap::Unwrap<Matrix>(info.This());
+  self->mat.addref();
+
+  return;
+}
+
+
+NAN_METHOD(Matrix::GetrefCount) {
+  Nan::HandleScope scope;
+  Matrix *self = Nan::ObjectWrap::Unwrap<Matrix>(info.This());
+
+  int refcount = -1;
+  
+#if CV_MAJOR_VERSION >= 3
+    if (self->mat.u){
+        refcount = self->mat.u->refcount;
+    } else {
+        refcount = -1;
+    }
+#else
+    if (self->mat.refcount){
+        refcount = *self->mat.refcount);
+    } else {
+        refcount = -1;
+    }
+#endif    
+
+  info.GetReturnValue().Set(Nan::New<Number>(refcount));
+  return;
+}
+
 
 NAN_METHOD(Matrix::Subtract) {
   SETUP_FUNCTION(Matrix)

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -3051,7 +3051,7 @@ NAN_METHOD(Matrix::GetrefCount) {
     }
 #else
     if (self->mat.refcount){
-        refcount = *self->mat.refcount);
+        refcount = *(self->mat.refcount);
     } else {
         refcount = -1;
     }

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -134,7 +134,10 @@ public:
   JSFUNC(Shift)
   JSFUNC(Reshape)
 
+          
+  JSFUNC(Addref)
   JSFUNC(Release)
+  JSFUNC(GetrefCount)
 
   JSFUNC(Subtract)
   JSFUNC(Compare)

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -135,7 +135,8 @@ public:
   JSFUNC(Reshape)
 
           
-  JSFUNC(Addref)
+// leave this out - can't see a way it could be useful to us, as release() always completely forgets the data
+//JSFUNC(Addref)
   JSFUNC(Release)
   JSFUNC(GetrefCount)
 


### PR DESCRIPTION
Adds Matrix.getrefCount()
Only really useful for debugging, but not harmful
consider addref() to be detrimental - dangerous if someone used it by mistake.