### PR TITLE
Track external memory usage for matrices

### DIFF
--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -312,7 +312,7 @@ public:
         Matrix *matrix):
       Nan::AsyncWorker(callback),
       bg(bg),
-      matrix(matrix) {
+      matrix(new Matrix::Matrix(matrix)) {
     
   }
 
@@ -398,7 +398,7 @@ NAN_METHOD(BackgroundSubtractorWrap::Apply) {
     
     Nan::Callback *callback = new Nan::Callback(cb.As<Function>());
     Matrix *_img = Nan::ObjectWrap::Unwrap<Matrix>(info[0]->ToObject());      
-    Nan::AsyncQueueWorker(new AsyncBackgroundSubtractorWorker( callback, self, new Matrix::Matrix(_img)));
+    Nan::AsyncQueueWorker(new AsyncBackgroundSubtractorWorker( callback, self, _img));
     return;
   } else { //synchronous - return the image
 

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -309,10 +309,10 @@ public:
   AsyncBackgroundSubtractorWorker( 
         Nan::Callback *callback, 
         BackgroundSubtractorWrap *bg, 
-        Matrix *matrix):
+        Matrix *matrix_in):
       Nan::AsyncWorker(callback),
       bg(bg),
-      matrix(new Matrix::Matrix(matrix)) {
+      matrix(new Matrix(matrix_in)) {
     
   }
 

--- a/src/BackgroundSubtractor.cc
+++ b/src/BackgroundSubtractor.cc
@@ -255,10 +255,6 @@ NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
 
   
   try {
-    Local<Object> fgMask =
-        Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(fgMask);
-
     cv::Mat mat;
     if (Buffer::HasInstance(info[0])) {
       uint8_t *buf = (uint8_t *) Buffer::Data(info[0]->ToObject());
@@ -287,7 +283,7 @@ NAN_METHOD(BackgroundSubtractorWrap::ApplyMOG) {
 #endif
     }
     
-    img->mat = _fgMask;
+    Local<Object> fgMask = Matrix::CreateWrappedFromMat(_fgMask);
     mat.release();
 
     argv[0] = Nan::Null();
@@ -344,9 +340,7 @@ public:
   void HandleOKCallback() {
     Nan::HandleScope scope;
 
-    Local<Object> im_to_return= Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *imgout = Nan::ObjectWrap::Unwrap<Matrix>(im_to_return);
-    imgout->mat = _fgMask;
+    Local<Object> im_to_return = Matrix::CreateWrappedFromMat(_fgMask);
 
     Local<Value> argv[] = {
       Nan::Null()
@@ -372,7 +366,6 @@ NAN_METHOD(BackgroundSubtractorWrap::Apply) {
   SETUP_FUNCTION(BackgroundSubtractorWrap);
   int callback_arg = -1;
   int numargs = info.Length();
-  int success = 1;
   
   Local<Function> cb;
 
@@ -407,10 +400,7 @@ NAN_METHOD(BackgroundSubtractorWrap::Apply) {
   } else { //synchronous - return the image
 
     try {
-      Local<Object> fgMask =
-          Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-      Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(fgMask);
-      
+      Local<Object> fgMask;
       cv::Mat mat;
       if (Buffer::HasInstance(info[0])) {
         uint8_t *buf = (uint8_t *) Buffer::Data(info[0]->ToObject());
@@ -436,7 +426,7 @@ NAN_METHOD(BackgroundSubtractorWrap::Apply) {
   #else
       self->subtractor->operator()(mat, _fgMask);
   #endif
-      img->mat = _fgMask;
+      fgMask = Matrix::CreateWrappedFromMat(_fgMask);
       }
       
       mat.release();

--- a/src/Calib3D.cc
+++ b/src/Calib3D.cc
@@ -3,15 +3,6 @@
 
 #ifdef HAVE_OPENCV_CALIB3D
 
-inline Local<Object> matrixFromMat(cv::Mat &input) {
-  Local<Object> matrixWrap =
-      Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-  Matrix *matrix = Nan::ObjectWrap::Unwrap<Matrix>(matrixWrap);
-  matrix->mat = input;
-
-  return matrixWrap;
-}
-
 inline cv::Mat matFromMatrix(Local<Value> matrix) {
   Matrix* m = Nan::ObjectWrap::Unwrap<Matrix>(matrix->ToObject());
   return m->mat;
@@ -237,11 +228,11 @@ NAN_METHOD(Calib3D::CalibrateCamera) {
     ret->Set(Nan::New<String>("reprojectionError").ToLocalChecked(), Nan::New<Number>(error));
 
     // K
-    Local<Object> KMatrixWrap = matrixFromMat(K);
+    Local<Object> KMatrixWrap = Matrix::CreateWrappedFromMat(K);
     ret->Set(Nan::New<String>("K").ToLocalChecked(), KMatrixWrap);
 
     // dist
-    Local<Object> distMatrixWrap = matrixFromMat(dist);
+    Local<Object> distMatrixWrap = Matrix::CreateWrappedFromMat(dist);
     ret->Set(Nan::New<String>("distortion").ToLocalChecked(), distMatrixWrap);
 
     // Per frame R and t, skiping for now
@@ -287,11 +278,11 @@ NAN_METHOD(Calib3D::SolvePnP) {
     Local<Object> ret = Nan::New<Object>();
 
     // rvec
-    Local<Object> rMatrixWrap = matrixFromMat(rvec);
+    Local<Object> rMatrixWrap = Matrix::CreateWrappedFromMat(rvec);
     ret->Set(Nan::New<String>("rvec").ToLocalChecked(), rMatrixWrap);
 
     // tvec
-    Local<Object> tMatrixWrap = matrixFromMat(tvec);
+    Local<Object> tMatrixWrap = Matrix::CreateWrappedFromMat(tvec);
     ret->Set(Nan::New<String>("tvec").ToLocalChecked(), tMatrixWrap);
 
     // Return
@@ -334,7 +325,7 @@ NAN_METHOD(Calib3D::GetOptimalNewCameraMatrix) {
         newImageSize);
 
     // Wrap the output K
-    Local<Object> KMatrixWrap = matrixFromMat(Kout);
+    Local<Object> KMatrixWrap = Matrix::CreateWrappedFromMat(Kout);
 
     // Return the new K matrix
     info.GetReturnValue().Set(KMatrixWrap);
@@ -394,28 +385,28 @@ NAN_METHOD(Calib3D::StereoCalibrate) {
     // Make the output arguments
 
     // k1
-    Local<Object> K1MatrixWrap = matrixFromMat(k1);
+    Local<Object> K1MatrixWrap = Matrix::CreateWrappedFromMat(k1);
 
     // d1
-    Local<Object> d1MatrixWrap = matrixFromMat(d1);
+    Local<Object> d1MatrixWrap = Matrix::CreateWrappedFromMat(d1);
 
     // k2
-    Local<Object> K2MatrixWrap = matrixFromMat(k2);
+    Local<Object> K2MatrixWrap = Matrix::CreateWrappedFromMat(k2);
 
     // d2
-    Local<Object> d2MatrixWrap = matrixFromMat(d2);
+    Local<Object> d2MatrixWrap = Matrix::CreateWrappedFromMat(d2);
 
     // R
-    Local<Object> RMatrixWrap = matrixFromMat(R);
+    Local<Object> RMatrixWrap = Matrix::CreateWrappedFromMat(R);
 
     // t
-    Local<Object> tMatrixWrap = matrixFromMat(t);
+    Local<Object> tMatrixWrap = Matrix::CreateWrappedFromMat(t);
 
     // E
-    Local<Object> EMatrixWrap = matrixFromMat(E);
+    Local<Object> EMatrixWrap = Matrix::CreateWrappedFromMat(E);
 
     // F
-    Local<Object> FMatrixWrap = matrixFromMat(F);
+    Local<Object> FMatrixWrap = Matrix::CreateWrappedFromMat(F);
 
     // Add to return object
     ret->Set(Nan::New<String>("K1").ToLocalChecked(), K1MatrixWrap);
@@ -479,11 +470,11 @@ NAN_METHOD(Calib3D::StereoRectify) {
     // Make the return object
     Local<Object> ret = Nan::New<Object>();
 
-    ret->Set(Nan::New<String>("R1").ToLocalChecked(), matrixFromMat(R1));
-    ret->Set(Nan::New<String>("R2").ToLocalChecked(), matrixFromMat(R2));
-    ret->Set(Nan::New<String>("P1").ToLocalChecked(), matrixFromMat(P1));
-    ret->Set(Nan::New<String>("P2").ToLocalChecked(), matrixFromMat(P2));
-    ret->Set(Nan::New<String>("Q").ToLocalChecked(), matrixFromMat(Q));
+    ret->Set(Nan::New<String>("R1").ToLocalChecked(), Matrix::CreateWrappedFromMat(R1));
+    ret->Set(Nan::New<String>("R2").ToLocalChecked(), Matrix::CreateWrappedFromMat(R2));
+    ret->Set(Nan::New<String>("P1").ToLocalChecked(), Matrix::CreateWrappedFromMat(P1));
+    ret->Set(Nan::New<String>("P2").ToLocalChecked(), Matrix::CreateWrappedFromMat(P2));
+    ret->Set(Nan::New<String>("Q").ToLocalChecked(), Matrix::CreateWrappedFromMat(Q));
 
     // Return the rectification parameters
     info.GetReturnValue().Set(ret);
@@ -557,7 +548,7 @@ NAN_METHOD(Calib3D::ReprojectImageTo3D) {
     cv::reprojectImageTo3D(disparity, depthImage, Q);
 
     // Wrap the depth image
-    Local<Object> depthImageMatrix = matrixFromMat(depthImage);
+    Local<Object> depthImageMatrix = Matrix::CreateWrappedFromMat(depthImage);
 
     info.GetReturnValue().Set(depthImageMatrix);
   } catch (cv::Exception &e) {

--- a/src/CascadeClassifierWrap.cc
+++ b/src/CascadeClassifierWrap.cc
@@ -50,7 +50,7 @@ public:
       Matrix* im, double scale, int neighbors, int minw, int minh) :
       Nan::AsyncWorker(callback),
       cc(cc),
-      im(im),
+      im(new Matrix(im)), //copy the matrix so we aren't affected if the original is released
       scale(scale),
       neighbors(neighbors),
       minw(minw),
@@ -82,7 +82,9 @@ public:
 
   void HandleOKCallback() {
     Nan::HandleScope scope;
-    //  this->matrix->Unref();
+
+    delete im;
+    im = NULL;
 
     Local < Value > argv[2];
     v8::Local < v8::Array > arr = Nan::New < v8::Array > (this->res.size());

--- a/src/FaceRecognizer.cc
+++ b/src/FaceRecognizer.cc
@@ -48,8 +48,8 @@ Matrix *CreateFromMatrixOrFilename(Local<Value> v) {
   if (v->IsString()) {
     Matrix *im = new Matrix();
     std::string filename = std::string(*Nan::Utf8String(v->ToString()));
-    im->mat = cv::imread(filename);
-    Nan::AdjustExternalMemory(im->mat.dataend - im->mat.datastart);
+    im->setMat(cv::imread(filename));
+    return im;
     // std::cout<< im.size();
   } else {
     return new Matrix(Nan::ObjectWrap::Unwrap<Matrix>(v->ToObject()));
@@ -404,11 +404,9 @@ NAN_METHOD(FaceRecognizerWrap::Predict) {
 
   Matrix *m = CreateFromMatrixOrFilename(info[0]);
   if (m->mat.channels() == 3) {
-    Matrix *replacement = new Matrix();
-    cv::cvtColor(m->mat, replacement->mat, CV_RGB2GRAY);
-    Nan::AdjustExternalMemory(replacement->mat.dataend - replacement->mat.datastart);
-    delete m;
-    m = replacement;
+    cv::Mat grayMat;
+    cv::cvtColor(m->mat, grayMat, CV_RGB2GRAY);
+    m->setMat(grayMat);
   }
 
   Nan::Callback *callback = new Nan::Callback(cb.As<Function>());

--- a/src/FaceRecognizer.cc
+++ b/src/FaceRecognizer.cc
@@ -448,9 +448,7 @@ NAN_METHOD(FaceRecognizerWrap::GetMat) {
   m = self->rec->getMat(key);
 #endif
 
-  Local<Object> im = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-  Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im);
-  img->mat = m;
+  Local<Object> im = Matrix::CreateWrappedFromMat(m);
 
   info.GetReturnValue().Set(im);
 }

--- a/src/FaceRecognizer.cc
+++ b/src/FaceRecognizer.cc
@@ -27,6 +27,8 @@ namespace cv {
 #define FISHER 2
 
 // Todo, move somewhere useful
+// Note: References to the returned object here should not be retained past the end of the calling function.
+// Otherwise, node might not keep track of external memory usage correctly.
 cv::Mat fromMatrixOrFilename(Local<Value> v) {
   cv::Mat im;
   if (v->IsString()) {
@@ -38,6 +40,20 @@ cv::Mat fromMatrixOrFilename(Local<Value> v) {
     im = img->mat;
   }
   return im;
+}
+
+// Note: Use this function when you might need to retain the returned object past the end of the calling function,
+// such as in asynchronous methods
+Matrix *CreateFromMatrixOrFilename(Local<Value> v) {
+  if (v->IsString()) {
+    Matrix *im = new Matrix();
+    std::string filename = std::string(*Nan::Utf8String(v->ToString()));
+    im->mat = cv::imread(filename);
+    Nan::AdjustExternalMemory(im->mat.dataend - im->mat.datastart);
+    // std::cout<< im.size();
+  } else {
+    return new Matrix(Nan::ObjectWrap::Unwrap<Matrix>(v->ToObject()));
+  }
 }
 
 Nan::Persistent<FunctionTemplate> FaceRecognizerWrap::constructor;
@@ -188,7 +204,7 @@ Local<Value> UnwrapTrainingData(Nan::NAN_METHOD_ARGS_TYPE info,
     }
 
     int label = valarr->Get(0)->Uint32Value();
-    cv::Mat im = fromMatrixOrFilename(valarr->Get(1));
+    cv::Mat im = fromMatrixOrFilename(valarr->Get(1)); //this is ok because we clone the image
     im = im.clone();
     if (im.channels() == 3) {
       cv::cvtColor(im, im, CV_RGB2GRAY);
@@ -295,7 +311,9 @@ NAN_METHOD(FaceRecognizerWrap::PredictSync) {
 
   cv::Mat im = fromMatrixOrFilename(info[0]);  // TODO CHECK!
   if (im.channels() == 3) {
-    cv::cvtColor(im, im, CV_RGB2GRAY);
+    cv::Mat previous = im;
+    im = cv::Mat();
+    cv::cvtColor(previous, im, CV_RGB2GRAY);
   }
 
   int predictedLabel = -1;
@@ -322,10 +340,10 @@ NAN_METHOD(FaceRecognizerWrap::PredictSync) {
 
 class PredictASyncWorker: public Nan::AsyncWorker {
 public:
-  PredictASyncWorker(Nan::Callback *callback, cv::Ptr<cv::FaceRecognizer> rec, cv::Mat im) :
+  PredictASyncWorker(Nan::Callback *callback, cv::Ptr<cv::FaceRecognizer> rec, Matrix *matrix_in) :
       Nan::AsyncWorker(callback),
       rec(rec),
-      im(im) {
+      matrix(new Matrix(matrix_in)) {
     predictedLabel = -1;
     confidence = 0.0;
   }
@@ -334,7 +352,7 @@ public:
   }
 
   void Execute() {
-     this->rec->predict(this->im, this->predictedLabel, this->confidence);
+     rec->predict(matrix->mat, predictedLabel, confidence);
 #if CV_MAJOR_VERSION >= 3
     // Older versions of OpenCV3 incorrectly returned label=0 at
     // confidence=DBL_MAX instead of label=-1 on failure.  This can be removed
@@ -349,6 +367,9 @@ public:
 
   void HandleOKCallback() {
     Nan::HandleScope scope;
+
+    delete matrix;
+    matrix = NULL;
 
     v8::Local<v8::Object> res = Nan::New<Object>();
     res->Set(Nan::New("id").ToLocalChecked(), Nan::New<Number>(predictedLabel));
@@ -367,7 +388,7 @@ public:
 
 private:
   cv::Ptr<cv::FaceRecognizer> rec;
-  cv::Mat im;
+  Matrix *matrix;
   int predictedLabel;
   double confidence;
 };
@@ -381,13 +402,19 @@ NAN_METHOD(FaceRecognizerWrap::Predict) {
 
   REQ_FUN_ARG(1, cb);
 
-  cv::Mat im = fromMatrixOrFilename(info[0]);
-  if (im.channels() == 3) {
-    cv::cvtColor(im, im, CV_RGB2GRAY);
+  Matrix *m = CreateFromMatrixOrFilename(info[0]);
+  if (m->mat.channels() == 3) {
+    Matrix *replacement = new Matrix();
+    cv::cvtColor(m->mat, replacement->mat, CV_RGB2GRAY);
+    Nan::AdjustExternalMemory(replacement->mat.dataend - replacement->mat.datastart);
+    delete m;
+    m = replacement;
   }
 
   Nan::Callback *callback = new Nan::Callback(cb.As<Function>());
-  Nan::AsyncQueueWorker(new PredictASyncWorker(callback, self->rec, im));
+  Nan::AsyncQueueWorker(new PredictASyncWorker(callback, self->rec, m));
+
+  delete m;
 
   return;
 }

--- a/src/Features2d.cc
+++ b/src/Features2d.cc
@@ -16,10 +16,10 @@ void Features::Init(Local<Object> target) {
 
 class AsyncDetectSimilarity: public Nan::AsyncWorker {
 public:
-  AsyncDetectSimilarity(Nan::Callback *callback, cv::Mat image1, cv::Mat image2) :
+  AsyncDetectSimilarity(Nan::Callback *callback, Matrix *image1, Matrix *image2) :
       Nan::AsyncWorker(callback),
-      image1(image1),
-      image2(image2),
+      image1(new Matrix(image1)),
+      image2(new Matrix(image2)),
       dissimilarity(0) {
   }
 
@@ -42,11 +42,11 @@ public:
     std::vector<cv::KeyPoint> keypoints1;
     std::vector<cv::KeyPoint> keypoints2;
 
-    detector->detect(image1, keypoints1);
-    detector->detect(image2, keypoints2);
+    detector->detect(image1->mat, keypoints1);
+    detector->detect(image2->mat, keypoints2);
 
-    extractor->compute(image1, keypoints1, descriptors1);
-    extractor->compute(image2, keypoints2, descriptors2);
+    extractor->compute(image1->mat, keypoints1, descriptors1);
+    extractor->compute(image2->mat, keypoints2, descriptors2);
 
     matcher->match(descriptors1, descriptors2, matches);
 
@@ -85,6 +85,11 @@ public:
   void HandleOKCallback() {
     Nan::HandleScope scope;
 
+    delete image1;
+    delete image2;
+    image1 = NULL;
+    image2 = NULL;
+
     Local<Value> argv[2];
 
     argv[0] = Nan::Null();
@@ -94,8 +99,8 @@ public:
   }
 
 private:
-  cv::Mat image1;
-  cv::Mat image2;
+  Matrix *image1;
+  Matrix *image2;
   double dissimilarity;
 };
 
@@ -104,8 +109,8 @@ NAN_METHOD(Features::Similarity) {
 
   REQ_FUN_ARG(2, cb);
 
-  cv::Mat image1 = Nan::ObjectWrap::Unwrap<Matrix>(info[0]->ToObject())->mat;
-  cv::Mat image2 = Nan::ObjectWrap::Unwrap<Matrix>(info[1]->ToObject())->mat;
+  Matrix *image1 = Nan::ObjectWrap::Unwrap<Matrix>(info[0]->ToObject());
+  Matrix *image2 = Nan::ObjectWrap::Unwrap<Matrix>(info[1]->ToObject());
 
   Nan::Callback *callback = new Nan::Callback(cb.As<Function>());
 

--- a/src/ImgProc.cc
+++ b/src/ImgProc.cc
@@ -36,9 +36,7 @@ NAN_METHOD(ImgProc::DistanceTransform) {
     cv::distanceTransform(inputImage, outputImage, distType, 0);
 
     // Wrap the output image
-    Local<Object> outMatrixWrap = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *outMatrix = Nan::ObjectWrap::Unwrap<Matrix>(outMatrixWrap);
-    outMatrix->mat = outputImage;
+    Local<Object> outMatrixWrap = Matrix::CreateWrappedFromMat(outputImage);
 
     // Return the output image
     info.GetReturnValue().Set(outMatrixWrap);
@@ -75,9 +73,7 @@ NAN_METHOD(ImgProc::Undistort) {
     cv::undistort(inputImage, outputImage, K, dist);
 
     // Wrap the output image
-    Local<Object> outMatrixWrap = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *outMatrix = Nan::ObjectWrap::Unwrap<Matrix>(outMatrixWrap);
-    outMatrix->mat = outputImage;
+    Local<Object> outMatrixWrap = Matrix::CreateWrappedFromMat(outputImage);
 
     // Return the output image
     info.GetReturnValue().Set(outMatrixWrap);
@@ -128,13 +124,8 @@ NAN_METHOD(ImgProc::InitUndistortRectifyMap) {
     cv::initUndistortRectifyMap(K, dist, R, newK, imageSize, m1type, map1, map2);
 
     // Wrap the output maps
-    Local<Object> map1Wrap = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *map1Matrix = Nan::ObjectWrap::Unwrap<Matrix>(map1Wrap);
-    map1Matrix->mat = map1;
-
-    Local<Object> map2Wrap = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *map2Matrix = Nan::ObjectWrap::Unwrap<Matrix>(map2Wrap);
-    map2Matrix->mat = map2;
+    Local<Object> map1Wrap = Matrix::CreateWrappedFromMat(map1);
+    Local<Object> map2Wrap = Matrix::CreateWrappedFromMat(map2); 
 
     // Make a return object with the two maps
     Local<Object> ret = Nan::New<Object>();
@@ -181,9 +172,7 @@ NAN_METHOD(ImgProc::Remap) {
     cv::remap(inputImage, outputImage, map1, map2, interpolation);
 
     // Wrap the output image
-    Local<Object> outMatrixWrap = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *outMatrix = Nan::ObjectWrap::Unwrap<Matrix>(outMatrixWrap);
-    outMatrix->mat = outputImage;
+    Local<Object> outMatrixWrap = Matrix::CreateWrappedFromMat(outputImage);
 
     // Return the image
     info.GetReturnValue().Set(outMatrixWrap);
@@ -223,9 +212,7 @@ NAN_METHOD(ImgProc::GetStructuringElement) {
     cv::Mat mat = cv::getStructuringElement(shape, ksize);
 
     // Wrap the output image
-    Local<Object> outMatrixWrap = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *outMatrix = ObjectWrap::Unwrap<Matrix>(outMatrixWrap);
-    outMatrix->mat = mat;
+    Local<Object> outMatrixWrap = Matrix::CreateWrappedFromMat(mat);
 
     // Return the image
     info.GetReturnValue().Set(outMatrixWrap);

--- a/src/LDAWrap.cc
+++ b/src/LDAWrap.cc
@@ -66,9 +66,7 @@ NAN_METHOD(LDAWrap::SubspaceProject) {
 
   cv::Mat m = cv::subspaceProject(w->mat, mean->mat, src->mat);
 
-  Local<Object> im = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-  Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im);
-  img->mat = m;
+  Local<Object> im = Matrix::CreateWrappedFromMat(m);
 
   info.GetReturnValue().Set(im);
 }
@@ -92,9 +90,7 @@ NAN_METHOD(LDAWrap::SubspaceReconstruct) {
 
   cv::Mat m = cv::subspaceReconstruct(w->mat, mean->mat, src->mat);
 
-  Local<Object> im = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-  Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im);
-  img->mat = m;
+  Local<Object> im = Matrix::CreateWrappedFromMat(m);
 
   info.GetReturnValue().Set(im);
 }

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -2180,14 +2180,20 @@ NAN_METHOD(Matrix::WarpAffine) {
 NAN_METHOD(Matrix::PyrDown) {
   SETUP_FUNCTION(Matrix)
 
+  int oldSize = self->mat.dataend - self->mat.datastart;
   cv::pyrDown(self->mat, self->mat);
+  int newSize = self->mat.dataend - self->mat.datastart;
+  Nan::AdjustExternalMemory(newSize - oldSize);
   return;
 }
 
 NAN_METHOD(Matrix::PyrUp) {
   SETUP_FUNCTION(Matrix)
 
+  int oldSize = self->mat.dataend - self->mat.datastart;
   cv::pyrUp(self->mat, self->mat);
+  int newSize = self->mat.dataend - self->mat.datastart;
+  Nan::AdjustExternalMemory(newSize - oldSize);
   return;
 }
 

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -2067,10 +2067,13 @@ NAN_METHOD(Matrix::Resize) {
   } else {
     try{
         Matrix *self = Nan::ObjectWrap::Unwrap<Matrix>(info.This());
+        int oldSize = self->mat.rows * self->mat.cols * self->mat.elemSize();
         cv::Mat res = cv::Mat(x, y, CV_32FC3);
         cv::resize(self->mat, res, cv::Size(x, y), 0, 0, interpolation);
         ~self->mat;
         self->mat = res;
+        int newSize = self->mat.rows * self->mat.cols * self->mat.elemSize();
+        Nan::AdjustExternalMemory(newSize - oldSize);
     } catch (...){
         return Nan::ThrowError("c++ Exception processing resize");
     }

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -8,7 +8,10 @@ public:
   static void Init(Local<Object> target);
   static NAN_METHOD(New);
   static Local<Object> CreateWrappedFromMat(cv::Mat mat);
+  static Local<Object> CreateWrappedFromMatIfNotReferenced(cv::Mat mat, int baseRefCount);
+  int getWrappedRefCount();
   Matrix();
+  Matrix(Matrix *other);
   Matrix(cv::Mat other, cv::Rect roi);
   Matrix(int rows, int cols);
   Matrix(int rows, int cols, int type);

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -10,6 +10,7 @@ public:
   static Local<Object> CreateWrappedFromMat(cv::Mat mat);
   static Local<Object> CreateWrappedFromMatIfNotReferenced(cv::Mat mat, int baseRefCount);
   int getWrappedRefCount();
+  void setMat(cv::Mat mat);
   Matrix();
   Matrix(Matrix *other);
   Matrix(cv::Mat other, cv::Rect roi);

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -7,11 +7,13 @@ public:
   static Nan::Persistent<FunctionTemplate> constructor;
   static void Init(Local<Object> target);
   static NAN_METHOD(New);
+  static Local<Object> CreateWrappedFromMat(cv::Mat mat);
   Matrix();
   Matrix(cv::Mat other, cv::Rect roi);
   Matrix(int rows, int cols);
   Matrix(int rows, int cols, int type);
   Matrix(int rows, int cols, int type, Local<Object> scalarObj);
+  ~Matrix();
 
   static double DblGet(cv::Mat mat, int i, int j);
 

--- a/src/OpenCV.cc
+++ b/src/OpenCV.cc
@@ -140,7 +140,7 @@ NAN_METHOD(OpenCV::ReadImageAsync) {
   argv[0] = Nan::Null();
   argv[1] = Nan::Null();
 
-    int callback_arg = -1;
+  int callback_arg = -1;
   int numargs = info.Length();
   
   Local<Function> cb;
@@ -257,13 +257,9 @@ NAN_METHOD(OpenCV::ReadImageAsync) {
 NAN_METHOD(OpenCV::ReadImage) {
   Nan::EscapableHandleScope scope;
 
-
   Local<Value> argv[2];
   argv[0] = Nan::Null();
-
-  Local<Object> im_h = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-  Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im_h);
-  argv[1] = im_h;
+  argv[1] = Nan::Null();
 
   int callback_arg = -1;
   int numargs = info.Length();
@@ -319,8 +315,7 @@ NAN_METHOD(OpenCV::ReadImage) {
       
     }
 
-    img->mat = mat;
-    Nan::AdjustExternalMemory(img->mat.dataend - img->mat.datastart);
+    argv[1] = Matrix::CreateWrappedFromMat(mat);
   } catch (cv::Exception& e) {
     argv[0] = Nan::Error(e.what());
     argv[1] = Nan::Null();
@@ -335,7 +330,7 @@ NAN_METHOD(OpenCV::ReadImage) {
   } else {
     // if to return the mat
     if (success)
-      info.GetReturnValue().Set(im_h);
+      info.GetReturnValue().Set(argv[1]);
     else
       info.GetReturnValue().Set(Nan::New<Boolean>(false));
   }

--- a/src/OpenCV.cc
+++ b/src/OpenCV.cc
@@ -49,6 +49,7 @@ public:
 
         try{
             Local<Object> im_to_return = Matrix::CreateWrappedFromMat(outputmat);
+            outputmat.release();
 
             Local<Value> argv[] = {
               Nan::Null(),
@@ -110,6 +111,7 @@ public:
     Nan::HandleScope scope;
 
     Local<Object> im_to_return = Matrix::CreateWrappedFromMat(outputmat);
+    outputmat.release();
     
     Local<Value> argv[] = {
       Nan::Null(),
@@ -165,7 +167,7 @@ NAN_METHOD(OpenCV::ReadImageAsync) {
       
       width = info[0]->Uint32Value();
       height = info[1]->Uint32Value();
-      Local<Object> img_to_return = Matrix::CreateWrappedFromMat(*(new cv::Mat(width, height, type)));
+      Local<Object> img_to_return = Matrix::CreateWrappedFromMat(cv::Mat(width, height, type));
       if (callback_arg < 0){
         info.GetReturnValue().Set(img_to_return);
         return;
@@ -287,7 +289,7 @@ NAN_METHOD(OpenCV::ReadImage) {
       }
       width = info[0]->Uint32Value();
       height = info[1]->Uint32Value();
-      mat = *(new cv::Mat(width, height, type));
+      mat = cv::Mat(width, height, type);
 
     } else if (info[0]->IsString()) {
       std::string filename = std::string(*Nan::Utf8String(info[0]->ToString()));
@@ -318,7 +320,7 @@ NAN_METHOD(OpenCV::ReadImage) {
     }
 
     img->mat = mat;
-    Nan::AdjustExternalMemory(img->mat.rows * img->mat.cols * img->mat.elemSize());
+    Nan::AdjustExternalMemory(img->mat.dataend - img->mat.datastart);
   } catch (cv::Exception& e) {
     argv[0] = Nan::Error(e.what());
     argv[1] = Nan::Null();

--- a/src/OpenCV.cc
+++ b/src/OpenCV.cc
@@ -48,9 +48,7 @@ public:
         Nan::HandleScope scope;
 
         try{
-            Local<Object> im_to_return= Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-            Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im_to_return);
-            img->mat = outputmat;
+            Local<Object> im_to_return = Matrix::CreateWrappedFromMat(outputmat);
 
             Local<Value> argv[] = {
               Nan::Null(),
@@ -111,9 +109,7 @@ public:
   void HandleOKCallback() {
     Nan::HandleScope scope;
 
-    Local<Object> im_to_return= Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im_to_return);
-    img->mat = outputmat;
+    Local<Object> im_to_return = Matrix::CreateWrappedFromMat(outputmat);
     
     Local<Value> argv[] = {
       Nan::Null(),
@@ -169,10 +165,7 @@ NAN_METHOD(OpenCV::ReadImageAsync) {
       
       width = info[0]->Uint32Value();
       height = info[1]->Uint32Value();
-      Local<Object> img_to_return =
-        Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-      Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(img_to_return);
-      img->mat = *(new cv::Mat(width, height, type));
+      Local<Object> img_to_return = Matrix::CreateWrappedFromMat(*(new cv::Mat(width, height, type)));
       if (callback_arg < 0){
         info.GetReturnValue().Set(img_to_return);
         return;
@@ -197,10 +190,7 @@ NAN_METHOD(OpenCV::ReadImageAsync) {
         }
       }
       if (callback_arg < 0){
-        Local<Object> img_to_return =
-            Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-        Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(img_to_return);
-        img->mat = cv::imread(filename, flags);
+        Local<Object> img_to_return = Matrix::CreateWrappedFromMat(cv::imread(filename, flags));
         info.GetReturnValue().Set(img_to_return);
         return;
       } else {
@@ -222,13 +212,10 @@ NAN_METHOD(OpenCV::ReadImageAsync) {
         }
       }
       if (callback_arg < 0){
-        Local<Object> img_to_return =
-            Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-        Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(img_to_return);
         uint8_t *buf = (uint8_t *) Buffer::Data(info[0]->ToObject());
         unsigned len = Buffer::Length(info[0]->ToObject());
         cv::Mat *mbuf = new cv::Mat(len, 1, CV_64FC1, buf);
-        img->mat = cv::imdecode(*mbuf, flags);
+        Local<Object> img_to_return = Matrix::CreateWrappedFromMat(cv::imdecode(*mbuf, flags));
         info.GetReturnValue().Set(img_to_return);
         return;
       } else {
@@ -331,6 +318,7 @@ NAN_METHOD(OpenCV::ReadImage) {
     }
 
     img->mat = mat;
+    Nan::AdjustExternalMemory(img->mat.rows * img->mat.cols * img->mat.elemSize());
   } catch (cv::Exception& e) {
     argv[0] = Nan::Error(e.what());
     argv[1] = Nan::Null();
@@ -383,10 +371,7 @@ NAN_METHOD(OpenCV::ReadImageMulti) {
   argv[1] = output;
 
   for (std::vector<cv::Mat>::size_type i = 0; i < mats.size(); i ++) {
-    Local<Object> im_h = Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im_h);
-    img->mat = mats[i];
-
+    Local<Object> im_h = Matrix::CreateWrappedFromMat(mats[i]);
     output->Set(i, im_h);
   }
 

--- a/src/Stereo.cc
+++ b/src/Stereo.cc
@@ -93,10 +93,7 @@ NAN_METHOD(StereoBM::Compute) {
     self->stereo(left, right, disparity, type);
 
     // Wrap the returned disparity map
-    Local < Object > disparityWrap =
-        Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *disp = Nan::ObjectWrap::Unwrap<Matrix>(disparityWrap);
-    disp->mat = disparity;
+    Local < Object > disparityWrap = Matrix::CreateWrappedFromMat(disparity);
 
     info.GetReturnValue().Set(disparityWrap);
 
@@ -228,10 +225,7 @@ NAN_METHOD(StereoSGBM::Compute) {
     self->stereo(left, right, disparity);
 
     // Wrap the returned disparity map
-    Local < Object > disparityWrap =
-        Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *disp = Nan::ObjectWrap::Unwrap<Matrix>(disparityWrap);
-    disp->mat = disparity;
+    Local < Object > disparityWrap = Matrix::CreateWrappedFromMat(disparity);
 
     info.GetReturnValue().Set(disparityWrap);
   } catch (cv::Exception &e) {
@@ -312,10 +306,7 @@ NAN_METHOD(StereoGC::Compute) {
     disp16.convertTo(disparity, CV_8U, -16);
 
     // Wrap the returned disparity map
-    Local < Object > disparityWrap =
-        Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *disp = Nan::ObjectWrap::Unwrap<Matrix>(disparityWrap);
-    disp->mat = disparity;
+    Local < Object > disparityWrap = Matrix::CreateWrappedFromMat(disparity);
 
     info.GetReturnValue().Set(disparityWrap);
   } catch (cv::Exception &e) {

--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -237,9 +237,7 @@ public:
   void HandleOKCallback() {
     Nan::HandleScope scope;
 
-    Local<Object> im_to_return= Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-    Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im_to_return);
-    img->mat = mat;
+    Local<Object> im_to_return = Matrix::CreateWrappedFromMat(mat);
 
     Local<Value> argv[] = {
       Nan::Null()
@@ -280,6 +278,7 @@ NAN_METHOD(VideoCaptureWrap::ReadSync) {
   Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im_to_return);
 
   v->cap.read(img->mat);
+  Nan::AdjustExternalMemory(img->mat.rows * img->mat.cols * img->mat.elemSize());
 
   info.GetReturnValue().Set(im_to_return);
 }

--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -40,7 +40,7 @@ void VideoCaptureWrap::Init(Local<Object> target) {
   Nan::SetPrototypeMethod(ctor, "getFPS", GetFPS);
   Nan::SetPrototypeMethod(ctor, "setFPS", SetFPS);
   Nan::SetPrototypeMethod(ctor, "release", Release);
-  Nan::SetPrototypeMethod(ctor, "ReadSync", ReadSync);
+  Nan::SetPrototypeMethod(ctor, "readSync", ReadSync);
   Nan::SetPrototypeMethod(ctor, "grab", Grab);
   Nan::SetPrototypeMethod(ctor, "retrieve", Retrieve);
 
@@ -238,6 +238,7 @@ public:
     Nan::HandleScope scope;
 
     Local<Object> im_to_return = Matrix::CreateWrappedFromMat(mat);
+    mat.release();
 
     Local<Value> argv[] = {
       Nan::Null()
@@ -274,11 +275,10 @@ NAN_METHOD(VideoCaptureWrap::ReadSync) {
   Nan::HandleScope scope;
   VideoCaptureWrap *v = Nan::ObjectWrap::Unwrap<VideoCaptureWrap>(info.This());
 
-  Local<Object> im_to_return= Nan::NewInstance(Nan::GetFunction(Nan::New(Matrix::constructor)).ToLocalChecked()).ToLocalChecked();
-  Matrix *img = Nan::ObjectWrap::Unwrap<Matrix>(im_to_return);
+  cv::Mat outputmat = cv::Mat();
+  v->cap.read(outputmat);
 
-  v->cap.read(img->mat);
-  Nan::AdjustExternalMemory(img->mat.rows * img->mat.cols * img->mat.elemSize());
+  Local<Object> im_to_return = Matrix::CreateWrappedFromMat(outputmat);
 
   info.GetReturnValue().Set(im_to_return);
 }

--- a/test/memory.js
+++ b/test/memory.js
@@ -825,6 +825,43 @@ test("Matrix reshape", t=>{
 	t.end();
 });
 
+test("Matrix pyrDown", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	image.pyrDown();
+
+	t.equal(process.memoryUsage().external - startingMemory, 7500); //50 * 50 * 3
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix pyrUp", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	image.pyrUp();
+
+	t.equal(process.memoryUsage().external - startingMemory, 120000); //200 * 200 * 3
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+
 //********************
 // Additional Asynchronous Matrix Functions
 //********************

--- a/test/memory.js
+++ b/test/memory.js
@@ -1,0 +1,980 @@
+require("v8").setFlagsFromString('--expose_gc');
+var gc = require("vm").runInNewContext('gc');
+
+var fs = require('fs')
+  , path = require('path') 
+  , test = require('tape')
+  , cv = require('../lib/opencv');
+
+ var IMAGE_PATH = path.resolve(__dirname, '../examples/files', 'mona.png');
+ var TEMP_SAVE_PATH = path.resolve(__dirname, '../examples/tmp', 'out.jpg');
+
+// These tests check that every function that creates or modifies a Matrix handles its externally tracked memory correctly.
+// Since the memory tracker uses OpenCV's reference counting to determine when to tell Node about memory changes,
+// it is important that only Matrix objects that Javascript knows about retain references to internal OpenCV Mat objects.
+// Reference counts for newly created objects should ususally therefore be 1, and releasing them should alter the 
+// externally tracked memory appropriately.
+
+// Note that garbage collection could run at any time, which could interfere with measurements of external memory,
+// so these tests manually run garbage collection as part of their setup to minimize this possibility.
+
+//********************
+// Image Reading
+//********************
+
+test("readImage", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = cv.readImage(IMAGE_PATH);
+
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 1134000); //image is tracked as external memory
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("readImage creating a new 100x100 matrix", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = cv.readImage(100,100);
+
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 80000); //image is tracked as external memory
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("readImage from data buffer", t=>{
+	gc();
+	var buffer = fs.readFileSync(IMAGE_PATH);
+	var startingMemory = process.memoryUsage().external;
+
+	var image = cv.readImage(buffer);
+
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 1134000); //image is tracked as external memory
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("readImage (callback pattern)", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	cv.readImage(IMAGE_PATH, (err, image) => {
+		t.equal(image.getrefCount(), 1);
+		t.equal(process.memoryUsage().external - startingMemory, 1134000); //image is tracked as external memory
+
+		image.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+		t.end();
+	});
+});
+
+test("readImage creating a new 100x100 matrix (callback pattern)", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	cv.readImage(100, 100, (err, image) => {
+		t.equal(image.getrefCount(), 1);
+		t.equal(process.memoryUsage().external - startingMemory, 80000); //image is tracked as external memory
+
+		image.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+		t.end();
+	});
+});
+
+test("readImage from data buffer (callback pattern)", t=>{
+	gc();
+	var buffer = fs.readFileSync(IMAGE_PATH);
+	var startingMemory = process.memoryUsage().external;
+
+	cv.readImage(buffer, (err, image) => {
+		t.equal(image.getrefCount(), 1);
+		t.equal(process.memoryUsage().external - startingMemory, 1134000); //image is tracked as external memory
+
+		image.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+		t.end();
+	});
+});
+
+test("readImageAsync", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	cv.readImageAsync(IMAGE_PATH, (err, image) => {
+		t.equal(image.getrefCount(), 1);
+		t.equal(process.memoryUsage().external - startingMemory, 1134000); //image is tracked as external memory
+
+		image.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+		t.end();
+	});
+});
+
+test("readImageAsync creating a new 100x100 matrix", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	cv.readImageAsync(100, 100, (err, image) => {
+		t.equal(image.getrefCount(), 1);
+		t.equal(process.memoryUsage().external - startingMemory, 80000); //image is tracked as external memory
+
+		image.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+		t.end();
+	});
+});
+
+test("readImageAsync from data buffer", t=>{
+	gc();
+	var buffer = fs.readFileSync(IMAGE_PATH);
+	var startingMemory = process.memoryUsage().external;
+
+	cv.readImageAsync(buffer, (err, image) => {
+		t.equal(image.getrefCount(), 1);
+		t.equal(process.memoryUsage().external - startingMemory, 1134000); //image is tracked as external memory
+
+		image.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+		t.end();
+	});
+});
+
+test("video capture async", t=>{
+	gc();
+	var vid = new cv.VideoCapture(path.resolve(__dirname, '../examples/files', 'motion.mov'));
+
+	var startingMemory = process.memoryUsage().external;
+
+	vid.read( (err, im) => {
+
+		t.equal(im.getrefCount(), 1);
+		t.equal(process.memoryUsage().external - startingMemory, 545280); //image is tracked as external memory
+
+		im.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+		t.end();
+	});
+});
+
+test("video capture sync", t=>{
+	gc();
+	var vid = new cv.VideoCapture(path.resolve(__dirname, '../examples/files', 'motion.mov'));
+
+	var startingMemory = process.memoryUsage().external;
+
+	var im = vid.readSync();
+
+	t.equal(im.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 545280);
+
+	im.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+//********************
+// Matrix Constructors
+//********************
+
+// Base constructor, doesn't actually allocate any memory
+test("Matrix()", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix();
+
+	t.equal(image.getrefCount(), -1);
+	t.equal(process.memoryUsage().external - startingMemory, 0);
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+// Constructor with a size
+test("Matrix(int, int)", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(100, 100);
+
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 120000); //100 * 100 * size of CV_32FC3 (12)
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+// Constructor with a size and type
+test("Matrix(int, int, type)", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(100, 100, cv.Constants.CV_8UC1);
+
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 10000); //100 * 100
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+// Constructor with a size, type, and initial values
+test("Matrix(int, int, type, [values])", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+
+// Constructor with an existing matrix and a region of interest
+test("Matrix(Matrix, x, y, w, h)", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	var image = new cv.Matrix(originalImage, 25, 25, 50, 50);        //this should share memory with the original
+	t.equal(image.getrefCount(), 2);                                 //so the refcount goes up
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //but the memory usage does not
+
+	originalImage.release();
+	t.equal(originalImage.getrefCount(), -1);
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); 
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix.Zeros", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = cv.Matrix.Zeros(100, 100);
+
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 80000); //100 * 100 * size of CV_64FC1
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix.Ones", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = cv.Matrix.Ones(100, 100);
+
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 80000); //100 * 100 * size of CV_64FC1
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix.Eye", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = cv.Matrix.Eye(100, 100);
+
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 80000); //100 * 100 * size of CV_64FC1
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+//********************
+// Matrix Functions
+//********************
+
+test("Matrix clone", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	var image = originalImage.clone();
+
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 60000);
+
+	originalImage.release();
+	t.equal(originalImage.getrefCount(), -1);
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); 
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix crop", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+	t.equal(originalImage.height(), 100);
+
+	var image = originalImage.crop(25, 25, 50, 50); //crops share memory with the original
+	t.equal(originalImage.height(), 100);
+	t.equal(image.height(), 50);
+	t.equal(image.getrefCount(), 2);
+	t.equal(process.memoryUsage().external - startingMemory, 30000);
+
+	originalImage.release();
+	t.equal(originalImage.getrefCount(), -1);
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); 
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+//ROI in this implementation is basically the same thing as crop
+test("Matrix roi", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+	t.equal(originalImage.height(), 100);
+
+	var image = originalImage.roi(25, 25, 50, 50); //ROIs share memory with the original
+	t.equal(originalImage.height(), 100);
+	t.equal(image.height(), 50);
+	t.equal(image.getrefCount(), 2);
+	t.equal(process.memoryUsage().external - startingMemory, 30000);
+
+	originalImage.release();
+	t.equal(originalImage.getrefCount(), -1);
+	t.equal(image.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); 
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix convertGrayscale", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	originalImage.convertGrayscale();
+	t.equal(process.memoryUsage().external - startingMemory, 10000); //grayscale takes less space
+	t.equal(originalImage.getrefCount(), 1);
+
+	originalImage.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix sobel", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	var resultImage = originalImage.sobel(cv.Constants.CV_16S, 1, 1);
+
+	t.equal(process.memoryUsage().external - startingMemory, 90000); //our original 30k image plus our new 60k one
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(resultImage.getrefCount(), 1);
+
+	originalImage.release();
+	resultImage.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix copy", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	var resultImage = originalImage.copy(0);
+
+	t.equal(process.memoryUsage().external - startingMemory, 60000); //our original image plus our new one
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(resultImage.getrefCount(), 1);
+
+	originalImage.release();
+	resultImage.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix flip", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	var resultImage = originalImage.flip(0);
+
+	t.equal(process.memoryUsage().external - startingMemory, 60000); //our original image plus our new one
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(resultImage.getrefCount(), 1);
+
+	originalImage.release();
+	resultImage.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix dct", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_32F);
+	t.equal(process.memoryUsage().external - startingMemory, 40000); //100 * 100 * 4
+
+	var resultImage = originalImage.dct();
+
+	t.equal(process.memoryUsage().external - startingMemory, 80000); //our original image plus our new one
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(resultImage.getrefCount(), 1);
+
+	originalImage.release();
+	resultImage.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix idct", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_32F);
+	t.equal(process.memoryUsage().external - startingMemory, 40000); //100 * 100 * 4
+
+	var resultImage = originalImage.idct();
+
+	t.equal(process.memoryUsage().external - startingMemory, 80000); //our original image plus our new one
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(resultImage.getrefCount(), 1);
+
+	originalImage.release();
+	resultImage.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix add", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var src1 = new cv.Matrix.Ones(100, 100);
+	var src2 = new cv.Matrix.Ones(100, 100);
+	t.equal(process.memoryUsage().external - startingMemory, 160000);
+
+	var resultMatrix = src1.add(src2);
+
+	t.equal(resultMatrix.get(0,0), 2); //just making sure the result is correct
+
+	t.equal(process.memoryUsage().external - startingMemory, 240000);
+	t.equal(src1.getrefCount(), 1);
+	t.equal(src2.getrefCount(), 1);
+	t.equal(resultMatrix.getrefCount(), 1);
+
+	src1.release();
+	src2.release();
+	resultMatrix.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix resize", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	image.resize(50, 50);
+	t.equal(process.memoryUsage().external - startingMemory, 7500); //50 * 50 * 3
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix resize async", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	image.resize(50, 50, (err, resizedImage)=>{
+		t.equal(image.height(), 100);      //we have both the original and the resized image
+		t.equal(resizedImage.height(), 50);
+
+		t.equal(image.getrefCount(), 1);
+		t.equal(resizedImage.getrefCount(), 1);
+
+
+		t.equal(process.memoryUsage().external - startingMemory, 37500);
+
+		image.release();
+		resizedImage.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+		t.end();
+	});	
+});
+
+test("Matrix resize async edge case", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(1000, 1000, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 3000000); //100 * 100 * 3
+
+	image.resize(50, 50, (err, resizedImage)=>{
+		t.equal(image.getrefCount(), -1);  //this happens second, image should have been released already
+		t.equal(resizedImage.getrefCount(), 1);
+
+		t.equal(process.memoryUsage().external - startingMemory, 7500);
+
+		resizedImage.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+		t.end();
+	});
+	image.release(); //this happens first
+});
+
+test("Matrix threshold", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_8U);
+	t.equal(process.memoryUsage().external - startingMemory, 10000); //100 * 100
+
+	var resultImage = originalImage.threshold(1,1);
+
+	t.equal(process.memoryUsage().external - startingMemory, 20000); //our original image plus our new one
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(resultImage.getrefCount(), 1);
+
+	originalImage.release();
+	resultImage.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix adaptiveThreshold", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var originalImage = new cv.Matrix(100, 100, cv.Constants.CV_8U);
+	t.equal(process.memoryUsage().external - startingMemory, 10000); //100 * 100
+
+	var resultImage = originalImage.adaptiveThreshold(255, 0, 0, 15, 2);
+
+	t.equal(process.memoryUsage().external - startingMemory, 20000); //our original image plus our new one
+	t.equal(originalImage.getrefCount(), 1);
+	t.equal(resultImage.getrefCount(), 1);
+
+	originalImage.release();
+	resultImage.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix meanStdDev", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var matrix = new cv.Matrix.Ones(100, 100, cv.Constants.CV_8UC3);
+	t.equal(process.memoryUsage().external - startingMemory, 30000);
+
+	var result = matrix.meanStdDev();
+
+	t.equal(result.mean.getrefCount(), 1);
+	t.equal(result.stddev.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30048);
+
+	matrix.release();
+	result.mean.release();
+	result.stddev.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix copyTo", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var smallImg = new cv.Matrix.Ones(25, 25, cv.Constants.CV_8UC3);
+	var bigImg = cv.Matrix.Zeros(100, 100, cv.Constants.CV_8UC3);
+	t.equal(process.memoryUsage().external - startingMemory, 30000 + 1875);
+
+	smallImg.copyTo(bigImg, 0, 0);
+
+	t.equal(smallImg.getrefCount(), 1);
+	t.equal(bigImg.getrefCount(), 1);
+	t.equal(process.memoryUsage().external - startingMemory, 30000 + 1875);
+
+	smallImg.release();
+	bigImg.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix cvtColor", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	image.cvtColor("CV_BGR2GRAY");
+	t.equal(process.memoryUsage().external - startingMemory, 10000); //grayscale is smaller
+
+	image.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix split", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	var result = image.split();
+	t.equal(process.memoryUsage().external - startingMemory, 60000);
+
+	image.release();
+	t.equal(process.memoryUsage().external - startingMemory, 30000);
+
+	result.forEach(m => m.release());
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix merge", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image1 = new cv.Matrix(100, 100, cv.Constants.CV_8UC1, [0]);
+	var image2 = new cv.Matrix(100, 100, cv.Constants.CV_8UC1, [0]);
+	var image3 = new cv.Matrix(100, 100, cv.Constants.CV_8UC1, [0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	var result = new cv.Matrix(10,10);
+	t.equal(process.memoryUsage().external - startingMemory, 30000 + 1200);
+
+	result.merge([image1, image2, image3]);
+
+	t.equal(process.memoryUsage().external - startingMemory, 60000);
+
+	result.release();
+	image1.release();
+	image2.release();
+	image3.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+test("Matrix reshape", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(100, 100, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //100 * 100 * 3
+
+	var result = image.reshape(2);
+
+	t.equal(process.memoryUsage().external - startingMemory, 30000); //reshape does not copy data, so the allocated size hasn't changed
+
+	image.release();
+
+	t.equal(process.memoryUsage().external - startingMemory, 30000);
+
+	result.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+	t.end();
+});
+
+//********************
+// Additional Asynchronous Matrix Functions
+//********************
+
+
+test("Matrix toBuffer async edge case", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(1000, 1000, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 3000000); //100 * 100 * 3
+
+	image.toBufferAsync((err, buffer)=>{
+		t.equal(image.getrefCount(), -1);  //this happens second, image should have been released already
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 33006); //the size of the buffer, which hasn't been released yet
+		t.end();
+	});
+	image.release();
+});
+
+test("Matrix save async edge case", t=>{
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(1000, 1000, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 3000000); //100 * 100 * 3
+
+	image.saveAsync(TEMP_SAVE_PATH, (err, buffer)=>{
+		t.equal(image.getrefCount(), -1);  //this happens second, image should have been released already
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+
+		fs.unlinkSync(TEMP_SAVE_PATH);
+		t.end();
+	});
+	image.release();
+});
+
+//********************
+// Background Subtractors
+//********************
+
+function testSyncBackgroundSubtractor(t, subtractor){
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(1000, 1000, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 3000000); //100 * 100 * 3
+
+	var output = subtractor.apply(image);
+	t.equal(image.getrefCount(), 1);
+	t.equal(output.getrefCount(), 1);
+
+	image.release();
+	output.release();
+
+	var endingMemory = process.memoryUsage().external;
+	t.equal(endingMemory - startingMemory, 0);
+
+	t.end();
+}
+
+function testAsyncBackgroundSubtractor(t, subtractor){
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(1000, 1000, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 3000000); //100 * 100 * 3
+
+	subtractor.apply(image, (err, output) => {
+		t.equal(image.getrefCount(), 1);
+		t.equal(output.getrefCount(), 1);
+
+		image.release();
+		output.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+
+		t.end();
+	});
+}
+
+function testAsyncBackgroundSubtractorEarlyRelease(t, subtractor){
+	gc();
+	var startingMemory = process.memoryUsage().external;
+
+	var image = new cv.Matrix(1000, 1000, cv.Constants.CV_8UC3, [0,0,0]);
+	t.equal(process.memoryUsage().external - startingMemory, 3000000); //100 * 100 * 3
+
+	subtractor.apply(image, (err, output) => {
+		t.equal(image.getrefCount(), -1);
+		t.equal(output.getrefCount(), 1);
+
+		output.release();
+
+		var endingMemory = process.memoryUsage().external;
+		t.equal(endingMemory - startingMemory, 0);
+
+		t.end();
+	});
+
+	image.release();
+}
+
+test("default background subtractor", t=>{
+	testSyncBackgroundSubtractor(t, new cv.BackgroundSubtractor());
+});
+
+test("MOG background subtractor", t=>{
+	testSyncBackgroundSubtractor(t, cv.BackgroundSubtractor.createMOG());
+});
+
+test("MOG2 background subtractor", t=>{
+	testSyncBackgroundSubtractor(t, cv.BackgroundSubtractor.createMOG2());
+});
+
+test("GMG background subtractor", t=>{
+	testSyncBackgroundSubtractor(t, cv.BackgroundSubtractor.createGMG());
+});
+
+test("default background subtractor async", t=>{
+	testAsyncBackgroundSubtractor(t, new cv.BackgroundSubtractor());
+});
+
+test("MOG background subtractor async", t=>{
+	testAsyncBackgroundSubtractor(t, cv.BackgroundSubtractor.createMOG());
+});
+
+test("MOG2 background subtractor async", t=>{
+	testAsyncBackgroundSubtractor(t, cv.BackgroundSubtractor.createMOG2());
+});
+
+test("GMG background subtractor async", t=>{
+	testAsyncBackgroundSubtractor(t, cv.BackgroundSubtractor.createGMG());
+});
+
+test("default background subtractor async early release", t=>{
+	testAsyncBackgroundSubtractorEarlyRelease(t, new cv.BackgroundSubtractor());
+});
+
+test("MOG background subtractor async early release", t=>{
+	testAsyncBackgroundSubtractorEarlyRelease(t, cv.BackgroundSubtractor.createMOG());
+});
+
+test("MOG2 background subtractor async early release", t=>{
+	testAsyncBackgroundSubtractorEarlyRelease(t, cv.BackgroundSubtractor.createMOG2());
+});
+
+test("GMG background subtractor async early release", t=>{
+	testAsyncBackgroundSubtractorEarlyRelease(t, cv.BackgroundSubtractor.createGMG());
+});


### PR DESCRIPTION
Adds tracking of the memory used by matrices to Node's external memory count, allowing the Javascript garbage collector to make better decisions about when to run.

Without these changes, Node only knows about the memory usage of the Javascript objects, and not the associated C and C++ objects. In the case of Matrix, those associated objects are quite large. As a result, it was possible to quickly allocate a large amount of memory without triggering garbage collection, for example: by reading multiple frames from a camera. This is especially problematic on low-memory systems, such as a Raspberry Pi, where memory usage could quickly grow past the available memory, triggering out-of-memory crashes.

To resolve this, this PR adds external memory adjustment calls to the Matrix wrapper class, and every location where the size of the referenced OpenCV matrix is altered, so that Node has a reasonable estimate of the memory usage of the Matrix objects. This causes garbage collection to run more often when needed, and prevents memory growth far outside of the bounds that Node is configured to run in.

It is still possible to use `Matrix.release()` to manually free memory, as this call has also been instrumented to adjust the external memory usage correctly.

Note that it is now important that every place that can change the size of the OpenCV Mat object referenced from a Matrix correctly adjusts the external memory usage (using `Nan::AdjustExternalMemory()`). If this is not done correctly, Node's external memory count could get out of sync with the library's actual memory usage, which could cause the garbage collector to run too often or not often enough.

I have attempted to find all the locations where these memory sizes could change, and have updated them in the least invasive way that I could. There might be better ways to restructure the code (for example, by strengthening the encapsulation of the referenced `Mat` within the `Matrix` wrapper class) to make some of this cleaner and safer, but that could be significantly more work and would probably change some of the usage patterns for the `Matrix` class.

In most cases, I was able to replace the code that creates a Javascript wrapped Matrix with a call to a helper method that does the same thing and correctly tracks the external memory size of the new object. A new destructor was also added to correctly reduce the tracked external memory size when the Matrix object is released.

I believe that this PR fixes #601, #411, #209, #167, and #101.