### PR TITLE
Pass back Matrix.floodFill() output bounding rect (plus quick unit test)

### DIFF
--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -2560,6 +2560,19 @@ NAN_METHOD(Matrix::FloodFill) {
       setColor(obj->Get(Nan::New<String>("loDiff").ToLocalChecked())->ToObject()),
       setColor(obj->Get(Nan::New<String>("upDiff").ToLocalChecked())->ToObject()), 4);
 
+  // Documentation notes that parameter "rect" is an optional output
+  // parameter which will hold the smallest possible bounding box of
+  // affected pixels. If "rect" was provided, let's update the values.
+  // (https://docs.opencv.org/2.4/modules/imgproc/doc/miscellaneous_transformations.html#floodfill)
+  if (!obj->Get(Nan::New<String>("rect").ToLocalChecked())->IsUndefined()) {
+    Local< Object > rectArgument =
+      obj->Get(Nan::New<String>("rect").ToLocalChecked())->ToObject();
+    rectArgument->Get(0)->ToObject()->Set(0, Nan::New<Number>(rect.x));
+    rectArgument->Get(0)->ToObject()->Set(1, Nan::New<Number>(rect.y));
+    rectArgument->Get(1)->ToObject()->Set(0, Nan::New<Number>(rect.width));
+    rectArgument->Get(1)->ToObject()->Set(1, Nan::New<Number>(rect.height));
+  }
+
   info.GetReturnValue().Set(Nan::New<Number>(ret));
 }
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -552,5 +552,40 @@ test('toArray/fromArray working in both ways', function(assert) {
   });
 });
 
+test('floodFill optional returned bounding rect', function(assert) {
+  var cv = require('../lib/opencv');
+  var solidImage = new cv.Matrix(
+    10, 15, // Create 15px wide by 10px tall image
+    cv.Constants.CV_8U);
+
+  // Define output rect
+  var rect = [
+    [0, 0], // x, y
+    [0, 0]  // width, height
+  ];
+
+  // Set all pixels to black/0
+  for (var y=0; y<solidImage.height(); y++) {
+    for (var x=0; x<solidImage.width(); x++) {
+      solidImage.pixel(y, x, [0]);
+    }
+  }
+  
+  // Fill entire image 
+  solidImage.floodFill({
+    seedPoint: [3, 2], // x=2, y=3
+    newColor: [128],
+    rect,
+    loDiff: 0,
+    upDiff: 0
+  });
+
+  assert.equal(rect[0][0], 0);  // Expect fill to go all the way to left edge
+  assert.equal(rect[0][1], 0);  // Expect fill to go all the way to top edge
+  assert.equal(rect[1][0], 15); // Expect fill to create 15px-wide bounding rect
+  assert.equal(rect[1][1], 10); // Expect fill to create 10px-tall bounding rect
+  assert.end();
+})
+
 // Test the examples folder.
 require('./examples')()

--- a/test/unit.js
+++ b/test/unit.js
@@ -585,7 +585,7 @@ test('floodFill optional returned bounding rect', function(assert) {
   assert.equal(rect[1][0], 15); // Expect fill to create 15px-wide bounding rect
   assert.equal(rect[1][1], 10); // Expect fill to create 10px-tall bounding rect
   assert.end();
-})
+});
 
 // Test the examples folder.
 require('./examples')()


### PR DESCRIPTION
OpenCV docs state the Matrix' floodFill() function will use the optionally passed-in rect parameter for return of the smallest possible bounding rectangle of affected pixels. Also adds quick unit test to verify this.