### PR TITLE
[OpenCV.h]: allow double arguments

### DIFF
--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -77,7 +77,7 @@ using namespace node;
   }
 
 #define DOUBLE_FROM_ARGS(NAME, IND) \
-  if (info[IND]->IsInt32()){ \
+  if (info[IND]->IsNumber()){ \
     NAME = info[IND]->NumberValue(); \
   }
 


### PR DESCRIPTION
Previously, if the input arguments were floating point, then this function would not assign them to the named value.

Fixes #598