### PR TITLE
Makefile: fix typo in Makefile: change NODE_GYP to NODE_PRE_GYP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ endif
 # The location of the `node-pre-gyp` module builder. Try and get a globally
 # installed version, falling back to a local install.
 NODE_PRE_GYP = $(shell which node-pre-gyp)
-ifeq ($(NODE_GYP),)
+ifeq ($(NODE_PRE_GYP),)
 	NODE_PRE_GYP = ./node_modules/.bin/node-pre-gyp
 endif
 


### PR DESCRIPTION
Makefile checks if there's node_pre_gyp installed on system. But
the variable is typing wrongly as NODE_GYP on the checking logic.
This commit fixes the typo.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>