### PR TITLE
Porting to OpenCV4

### DIFF
--- a/src/CamShift.cc
+++ b/src/CamShift.cc
@@ -8,6 +8,10 @@
 #include <opencv2/video/tracking.hpp>
 #endif
 
+#if CV_MAJOR_VERSION >= 4
+#include <opencv2/imgproc/types_c.h>
+#endif
+
 #define CHANNEL_HUE 0
 #define CHANNEL_SATURATION 1
 #define CHANNEL_VALUE 2

--- a/src/CascadeClassifierWrap.cc
+++ b/src/CascadeClassifierWrap.cc
@@ -3,6 +3,10 @@
 #include "Matrix.h"
 #include <nan.h>
 
+#if CV_MAJOR_VERSION >= 4
+#include <opencv2/imgproc/types_c.h>
+#endif
+
 #ifdef HAVE_OPENCV_OBJDETECT
 
 Nan::Persistent<FunctionTemplate> CascadeClassifierWrap::constructor;
@@ -73,7 +77,7 @@ public:
         gray = this->im->mat;
       }
       this->cc->cc.detectMultiScale(gray, objects, this->scale, this->neighbors,
-          0 | CV_HAAR_SCALE_IMAGE, cv::Size(this->minw, this->minh));
+          0 | cv::CASCADE_SCALE_IMAGE, cv::Size(this->minw, this->minh));
       res = objects;
     } catch (cv::Exception& e) {
       SetErrorMessage(e.what());

--- a/src/Constants.cc
+++ b/src/Constants.cc
@@ -1,6 +1,10 @@
 #include "OpenCV.h"
 #include "Constants.h"
 
+#if CV_MAJOR_VERSION >= 4
+#include <opencv2/imgproc/imgproc_c.h>
+#endif
+
 #define CONST(C) \
   obj->Set(Nan::New<String>(#C).ToLocalChecked(), Nan::New<Integer>(C));
 
@@ -25,7 +29,9 @@ void Constants::Init(Local<Object> target) {
   CONST(CV_32S);
   CONST(CV_32F);
   CONST(CV_64F);
+#if CV_MAJOR_VERSION <= 3
   CONST(CV_USRTYPE1);
+#endif
 
   CONST(CV_8UC1);
   CONST(CV_8UC2);

--- a/src/FaceRecognizer.cc
+++ b/src/FaceRecognizer.cc
@@ -4,9 +4,9 @@
 #include "FaceRecognizer.h"
 #include "Matrix.h"
 #include <nan.h>
+#include <opencv2/imgproc/types_c.h>
 
-#if CV_MAJOR_VERSION < 3
-#elif CV_MINOR_VERSION < 3
+#if CV_MAJOR_VERSION < 3 || (CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION < 3)
 namespace cv {
   using std::vector;
   using cv::face::createEigenFaceRecognizer;
@@ -92,7 +92,7 @@ NAN_METHOD(FaceRecognizerWrap::New) {
   }
 
   // By default initialize LBPH
-#if CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3
+#if CV_MAJOR_VERSION >= 4 || (CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3)
   cv::Ptr<cv::FaceRecognizer> f = cv::LBPHFaceRecognizer::create(1, 8, 8, 8, 80.0);
 #else 
   cv::Ptr<cv::FaceRecognizer> f = cv::createLBPHFaceRecognizer(1, 8, 8, 8, 80.0);
@@ -119,7 +119,7 @@ NAN_METHOD(FaceRecognizerWrap::CreateLBPH) {
   DOUBLE_FROM_ARGS(threshold, 4)
 
   Local<Object> n = Nan::NewInstance(Nan::GetFunction(Nan::New(FaceRecognizerWrap::constructor)).ToLocalChecked()).ToLocalChecked();
-#if CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3
+#if CV_MAJOR_VERSION >= 4 || (CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3)
   cv::Ptr<cv::FaceRecognizer> f = cv::LBPHFaceRecognizer::create(radius, neighbors, grid_x, grid_y, threshold);
 #else 
   cv::Ptr<cv::FaceRecognizer> f = cv::createLBPHFaceRecognizer(radius, neighbors, grid_x, grid_y, threshold);
@@ -140,7 +140,7 @@ NAN_METHOD(FaceRecognizerWrap::CreateEigen) {
   DOUBLE_FROM_ARGS(threshold, 1)
 
   Local<Object> n = Nan::NewInstance(Nan::GetFunction(Nan::New(FaceRecognizerWrap::constructor)).ToLocalChecked()).ToLocalChecked();
-#if CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3
+#if CV_MAJOR_VERSION >= 4 || (CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3)
   cv::Ptr<cv::FaceRecognizer> f = cv::EigenFaceRecognizer::create(components, threshold);
 #else
   cv::Ptr<cv::FaceRecognizer> f = cv::createEigenFaceRecognizer(components, threshold);
@@ -161,7 +161,7 @@ NAN_METHOD(FaceRecognizerWrap::CreateFisher) {
   DOUBLE_FROM_ARGS(threshold, 1)
 
   Local<Object> n = Nan::NewInstance(Nan::GetFunction(Nan::New(FaceRecognizerWrap::constructor)).ToLocalChecked()).ToLocalChecked();
-#if CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3
+#if CV_MAJOR_VERSION >= 4 || (CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3)
   cv::Ptr<cv::FaceRecognizer> f = cv::FisherFaceRecognizer::create(components, threshold);
 #else
   cv::Ptr<cv::FaceRecognizer> f = cv::createFisherFaceRecognizer(components, threshold);
@@ -423,7 +423,7 @@ NAN_METHOD(FaceRecognizerWrap::SaveSync) {
     JSTHROW("Save takes a filename")
   }
   std::string filename = std::string(*Nan::Utf8String(info[0]->ToString()));
-#if CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3
+#if CV_MAJOR_VERSION >= 4 || (CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3)
   self->rec->write(filename);
 #else
   self->rec->save(filename);
@@ -437,7 +437,7 @@ NAN_METHOD(FaceRecognizerWrap::LoadSync) {
     JSTHROW("Load takes a filename")
   }
   std::string filename = std::string(*Nan::Utf8String(info[0]->ToString()));
-#if CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3  
+#if CV_MAJOR_VERSION >= 4 || (CV_MAJOR_VERSION >= 3  && CV_MINOR_VERSION >= 3)
   self->rec->read(filename);
 #else
   self->rec->load(filename);

--- a/src/Matrix.cc
+++ b/src/Matrix.cc
@@ -4,6 +4,11 @@
 #include <string.h>
 #include <nan.h>
 
+#if CV_MAJOR_VERSION >= 4
+#include <opencv2/imgproc/types_c.h>
+#include <opencv2/imgproc/imgproc_c.h>
+#endif
+
 Nan::Persistent<FunctionTemplate> Matrix::constructor;
 
 cv::Scalar setColor(Local<Object> objColor);
@@ -1609,7 +1614,9 @@ NAN_METHOD(Matrix::Canny) {
   int lowThresh = info[0]->NumberValue();
   int highThresh = info[1]->NumberValue();
 
-  cv::Canny(self->mat, self->mat, lowThresh, highThresh);
+  cv::Mat newMat;
+  cv::Canny(self->mat, newMat, lowThresh, highThresh);
+  newMat.copyTo(self->mat);
 
   info.GetReturnValue().Set(Nan::Null());
 }

--- a/src/OpenCV.h
+++ b/src/OpenCV.h
@@ -24,6 +24,8 @@
 
 #if ((CV_MAJOR_VERSION <= 2) && (CV_MINOR_VERSION <= 4))
 #include <opencv/highgui.h>
+#elif CV_MAJOR_VERSION >= 4
+#include <opencv2/imgcodecs/legacy/constants_c.h>
 #else
 #include <opencv2/imgcodecs/imgcodecs_c.h>
 #endif

--- a/src/Point.h
+++ b/src/Point.h
@@ -2,6 +2,10 @@
 
 #include "OpenCV.h"
 
+#if CV_MAJOR_VERSION >= 4
+#include <opencv2/core/types_c.h>
+#endif
+
 class Point: public Nan::ObjectWrap {
 public:
   CvPoint2D32f point;

--- a/src/VideoCaptureWrap.cc
+++ b/src/VideoCaptureWrap.cc
@@ -4,6 +4,10 @@
 
 #include  <iostream>
 
+#if CV_MAJOR_VERSION >= 4
+#include <opencv2/videoio/legacy/constants_c.h>
+#endif
+
 #ifdef HAVE_OPENCV_VIDEOIO
 
 Nan::Persistent<FunctionTemplate> VideoCaptureWrap::constructor;

--- a/src/VideoWriterWrap.cc
+++ b/src/VideoWriterWrap.cc
@@ -2,6 +2,10 @@
 #include "Matrix.h"
 #include "OpenCV.h"
 
+#if CV_MAJOR_VERSION >= 4
+#include <opencv2/videoio/legacy/constants_c.h>
+#endif
+
 #include  <iostream>
 
 #ifdef HAVE_OPENCV_VIDEOIO

--- a/utils/find-opencv.js
+++ b/utils/find-opencv.js
@@ -16,6 +16,7 @@ var flag = flags[process.argv[2]] || '--exists'
 // the same machine, the opencv.pc for 3.y can be installed as opencv3.pc and
 // then selected by |export PKG_CONFIG_OPENCV3=1| before building node-opencv.
 var opencv = process.env.PKG_CONFIG_OPENCV3 === "1" ? "opencv3" : ' "opencv >= 2.3.1"';
+opencv = process.env.PKG_CONFIG_OPENCV4 === "1" ? "opencv4" : opencv;
 
 function main(){
     //Try using pkg-config, but if it fails and it is on Windows, try the fallback


### PR DESCRIPTION
Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>

Debian recently transit to OpenCV4. I made a patch to porting node-opencv to OpenCV4.
It builds well and the unittest are all passed. [3] 
Please review the patch and see if it is good enough. 
Thanks.

[1] https://bugs.debian.org/922587
[2] https://github.com/peterbraden/node-opencv/issues/648
[3] https://buildd.debian.org/status/fetch.php?pkg=node-opencv&arch=amd64&ver=6.0.0%2Bgit20190322.db093cb2-1&stamp=1581110221&raw=0