### PR TITLE
src: FaceRecognizer.cc: fix FTBFS on nodejs 14

### DIFF
--- a/src/FaceRecognizer.cc
+++ b/src/FaceRecognizer.cc
@@ -199,12 +199,12 @@ Local<Value> UnwrapTrainingData(Nan::NAN_METHOD_ARGS_TYPE info,
 
     Local<Array> valarr = Local<Array>::Cast(val);
 
-    if (valarr->Length() != 2 || !valarr->Get(Nan::GetCurrentContext(),0)->IsInt32()) {
+    if (valarr->Length() != 2 || !valarr->Get(Nan::GetCurrentContext(),0).ToLocalChecked()->IsInt32()) {
       JSTHROW("train takes a list of [label, image] tuples")
     }
 
-    int label = valarr->Get(Nan::GetCurrentContext(),0)->Uint32Value(Nan::GetCurrentContext()).ToChecked();
-    cv::Mat im = fromMatrixOrFilename(valarr->Get(Nan::GetCurrentContext(),1)); //this is ok because we clone the image
+    int label = valarr->Get(Nan::GetCurrentContext(),0).ToLocalChecked()->Uint32Value(Nan::GetCurrentContext()).ToChecked();
+    cv::Mat im = fromMatrixOrFilename(valarr->Get(Nan::GetCurrentContext(),1).ToLocalChecked()); //this is ok because we clone the image
     im = im.clone();
     if (im.channels() == 3) {
       cv::cvtColor(im, im, CV_RGB2GRAY);


### PR DESCRIPTION
When building on Debian with nodejs 14, we got the following error:
 src/FaceRecognizer.cc:202:74: error: base operand of '->' has
   non-pointer type 'v8::MaybeLocal<v8::Value>'
 src/FaceRecognizer.cc:206:56: error: base operand of '->' has
   non-pointer type 'v8::MaybeLocal<v8::Value>'
 src/FaceRecognizer.cc:207:50: error: could not convert
   '((v8::Object*)valarr.v8::Local<v8::Array>::operator->())->
   v8::Object::Get(Nan::GetCurrentContext(), 1)' from
   'v8::MaybeLocal<v8::Value>' to 'v8::Local<v8::Value>'

This commit use .ToLocalChecked() to convert v8::MaybeLocal to v8::Local

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>